### PR TITLE
Fix undefined variables in profile query

### DIFF
--- a/backend/get_user_data.php
+++ b/backend/get_user_data.php
@@ -34,11 +34,6 @@ $stmt->bind_param("i", $user_id);
 $stmt->execute();
 $result = $stmt->get_result();
 
-$conn = new mysqli($db_host, $db_user, $db_pass, $db_name);
-if ($conn->connect_error) {
-    die(json_encode(['status' => 'error', 'message' => 'Kunne ikke koble til databasen']));
-}
-
 if ($result->num_rows > 0) {
     $user = $result->fetch_assoc();
     echo json_encode(['status' => 'success', 'user' => $user]);


### PR DESCRIPTION
## Summary
- clean up the user profile data endpoint by removing a second connection using undefined variables

## Testing
- `php -l backend/get_user_data.php` *(fails: `bash: php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6845fcde9e948333a60193b48e377ce7