### PR TITLE
Fix update_profile connection usage

### DIFF
--- a/backend/update_profile.php
+++ b/backend/update_profile.php
@@ -26,7 +26,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $shiftHide = isset($_POST['shift-hide']) ? 1 : 0;
         $shiftNa = isset($_POST['shift-na']) ? 1 : 0;
 
-        $conn = openDatabaseConnection();
 
         $sql = "UPDATE users SET firstname=?, email=?, company=?, company_hidden=?, company_na=?,
                 location=?, location_hidden=?, location_na=?, shift=?, shift_hidden=?, shift_na=?";


### PR DESCRIPTION
## Summary
- use `$conn` defined in `database.php` to run queries in `update_profile.php`

## Testing
- `php -l backend/update_profile.php` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849bbd71d1883339498449fe52f59ac