### PR TITLE
Restore update_profile defaults

### DIFF
--- a/backend/update_profile.php
+++ b/backend/update_profile.php
@@ -1,15 +1,17 @@
 <?php
 session_start();
 ob_clean();
-ini_set('display_errors', 1);
-ini_set('display_startup_errors', 1);
-error_reporting(E_ALL);
 
 header('Content-Type: application/json');
 include 'database.php';
 
-// Midlertidig hardkodet for testing
-$userId = 39;
+if (!isset($_SESSION['user_id'])) {
+    http_response_code(401);
+    echo json_encode(['status' => 'error', 'message' => 'Bruker ikke innlogget']);
+    exit;
+}
+
+$userId = $_SESSION['user_id'];
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     try {
@@ -26,7 +28,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $shiftHide = isset($_POST['shift-hide']) ? 1 : 0;
         $shiftNa = isset($_POST['shift-na']) ? 1 : 0;
 
-        $conn = openDatabaseConnection();
 
         $sql = "UPDATE users SET firstname=?, email=?, company=?, company_hidden=?, company_na=?,
                 location=?, location_hidden=?, location_na=?, shift=?, shift_hidden=?, shift_na=?";


### PR DESCRIPTION
## Summary
- fix login-based user id for profile updates
- remove debug error display statements

## Testing
- `php -l backend/update_profile.php` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849bbd71d1883339498449fe52f59ac