### PR TITLE
Use external config for credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+backend/config.php

--- a/backend/database.php
+++ b/backend/database.php
@@ -4,13 +4,16 @@ header("Access-Control-Allow-Origin: *");
 header("Access-Control-Allow-Methods: GET, POST");
 header("Access-Control-Allow-Headers: Content-Type");
 
+// Load credentials
+$config = require __DIR__ . '/config.php';
+
 // Fjern all feilrapportering for produksjon
 error_reporting(0);
 
 // Definer tilkoblingsinformasjon for MySQL-databasen
 $servername = "localhost";            // Vanligvis er det "localhost" for webhotell
-$username = "kalende1_admin";         // Brukernavnet du opprettet, inkludert prefixet
-$db_password = "Tomrefjord6390";      // Passordet du opprettet for brukeren
+$username = $config['DB_USER'];         // Brukernavnet fra config
+$db_password = $config['DB_PASS'];      // Passordet fra config
 $dbname = "kalende1_turnus";          // Navnet på databasen, inkludert prefixet
 
 // Lag tilkoblingen med MySQLi (denne brukes av andre skript ved behov)

--- a/backend/forgot_password.php
+++ b/backend/forgot_password.php
@@ -8,6 +8,7 @@ use PHPMailer\PHPMailer\Exception;
 require 'PHPMailer/src/Exception.php';
 require 'PHPMailer/src/PHPMailer.php';
 require 'PHPMailer/src/SMTP.php';
+$config = require __DIR__ . '/config.php';
 require_once 'database.php'; // Databasekonfigurasjon
 
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
@@ -48,8 +49,8 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
                 $mail->isSMTP();                                    
                 $mail->Host = 'cpanel02.dedia-server.no';          
                 $mail->SMTPAuth = true;                             
-                $mail->Username = 'thomas@kalenderturnus.no';       
-                $mail->Password = 'U=W623?8_)kM';                   
+                $mail->Username = $config['MAIL_USER'];
+                $mail->Password = $config['MAIL_PASS'];
                 $mail->SMTPSecure = PHPMailer::ENCRYPTION_SMTPS;    
                 $mail->Port = 465;                                  
 

--- a/backend/send_mail.php
+++ b/backend/send_mail.php
@@ -9,6 +9,7 @@ use PHPMailer\PHPMailer\Exception;
 require 'PHPMailer/src/Exception.php';
 require 'PHPMailer/src/PHPMailer.php';
 require 'PHPMailer/src/SMTP.php';
+$config = require __DIR__ . '/config.php';
 
 $mail = new PHPMailer(true);
 try {
@@ -16,8 +17,8 @@ try {
     $mail->isSMTP();                                      // Sett SMTP som e-post sendingens metode
     $mail->Host = 'cpanel02.dedia-server.no';             // SMTP-serverens host (fra bildet)
     $mail->SMTPAuth = true;                               // Aktiver SMTP-autentisering
-    $mail->Username = 'thomas@kalenderturnus.no';         // SMTP-brukernavn (e-postadresse)
-    $mail->Password = 'U=W623?8_)kM';                     // SMTP-passord (bruk e-postkontoens passord)
+    $mail->Username = $config['MAIL_USER'];         // SMTP-brukernavn fra config
+    $mail->Password = $config['MAIL_PASS'];         // SMTP-passord fra config
     $mail->SMTPSecure = PHPMailer::ENCRYPTION_SMTPS;      // Krypteringsmetode (bruk SSL/TLS)
     $mail->Port = 465;                                    // SMTP-port (465 for SSL fra bildet)
 


### PR DESCRIPTION
## Summary
- ignore `backend/config.php` so credentials aren't tracked
- load credentials from `config.php` in database and mail scripts

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849fbc66ca08333a11a73ae8729d68d