### PR TITLE
Fix PHP session logic and add JSON headers

### DIFF
--- a/backend/forgot_password.php
+++ b/backend/forgot_password.php
@@ -9,6 +9,7 @@ require 'PHPMailer/src/Exception.php';
 require 'PHPMailer/src/PHPMailer.php';
 require 'PHPMailer/src/SMTP.php';
 require_once 'database.php'; // Databasekonfigurasjon
+header('Content-Type: application/json');
 
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
     $input = json_decode(file_get_contents('php://input'), true);

--- a/backend/login.php
+++ b/backend/login.php
@@ -3,8 +3,8 @@ ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);
 error_reporting(E_ALL);
 session_start();
+header('Content-Type: application/json');
 require_once 'database.php';
-$_SESSION['user_id'] = $user['id'];  // Antar du har bruker-ID tilgjengelig
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
     // Hent input fra skjemaet
     $email = trim($_POST['email']);

--- a/backend/register.php
+++ b/backend/register.php
@@ -1,6 +1,7 @@
 <?php
 // Inkluder database.php for å koble til databasen
 require_once 'database.php';
+header('Content-Type: application/json');
 
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
     // Rens output-buffer for å sikre ren JSON-respons

--- a/backend/reset_password.php
+++ b/backend/reset_password.php
@@ -3,6 +3,7 @@ error_reporting(E_ALL);
 ini_set('display_errors', 1);
 
 require_once 'database.php'; // Inkluder databasekonfigurasjon
+header('Content-Type: application/json');
 
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
     $input = json_decode(file_get_contents('php://input'), true);

--- a/backend/session_status.php
+++ b/backend/session_status.php
@@ -1,8 +1,6 @@
 <?php
 session_start();
-echo '<pre>';
-print_r($_SESSION);
-echo '</pre>';
+header('Content-Type: application/json');
 
 
 if (isset($_SESSION['user_id'])) {


### PR DESCRIPTION
## Summary
- remove premature session assignment in `backend/login.php`
- send JSON responses with proper headers

## Testing
- `php -l backend/login.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6849fbf0b3ac833394509c768e75869f