### PR TITLE
Fix add-shift button logic

### DIFF
--- a/backend/login.php
+++ b/backend/login.php
@@ -4,7 +4,8 @@ ini_set('display_startup_errors', 1);
 error_reporting(E_ALL);
 session_start();
 require_once 'database.php';
-$_SESSION['user_id'] = $user['id'];  // Antar du har bruker-ID tilgjengelig
+
+// Start session variables only after the user has been authenticated
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
     // Hent input fra skjemaet
     $email = trim($_POST['email']);

--- a/js/kalender.js
+++ b/js/kalender.js
@@ -10,21 +10,6 @@ const calendarGrid = document.querySelector('.calendar-grid');
 
 console.log("🚀 kalender.js er lastet!");
 
-document.addEventListener("DOMContentLoaded", function() {
-    console.log("✅ DOM er ferdig lastet!");
-
-    const addShiftButton = document.getElementById('add-shift');
-    console.log("🔎 add-shift:", addShiftButton);
-
-    if (addShiftButton) {
-        console.log("✅ add-shift ble funnet! Legger til event listener...");
-        addShiftButton.addEventListener('click', addNewShift);
-    } else {
-        console.error("❌ Feil: add-shift knappen ble IKKE funnet!");
-    }
-});
-
-
 // Turnuser
 let shifts = [];
 const predefinedShifts = [
@@ -223,7 +208,7 @@ function addColorToDropdown(color) {
 
 // Funksjon for å legge til ny turnus
 function addNewShift() {
-    if (shifts.length >= 10) {
+    if (shifts.length >= maxShifts) {
         alert(`Maksimum antall turnuser er nådd. Slett en turnus for å legge til en ny.`);
         return;
     }
@@ -533,46 +518,6 @@ function renderShiftList() {
 
 // Legg til ny turnus
 const maxShifts = 10; // Sett maksgrensen her
-
-addShiftButton.addEventListener('click', () => {
-    if (shifts.length >= maxShifts) {
-        alert(`Maksimum antall turnuser er ${maxShifts}. Slett en turnus for å legge til en ny.`);
-        return;
-    }
-
-    const name = document.getElementById('shift-name').value;
-    const durationInput = document.getElementById('shift-duration').value;
-    let duration = durationInput;
-
-    // Egendefinert input
-    if (durationInput === 'custom') {
-        duration = document.getElementById('custom-shift').value;
-    }
-
-    const durationArray = duration.split('-').map(Number);
-    if (durationArray.length !== 2 || durationArray.some(isNaN) || durationArray.some(num => num <= 0)) {
-        alert('Ugyldig turnuslengde, bruk formatet "2-4"');
-        return;
-    }
-
-    const startDate = new Date(document.getElementById('shift-start').value);
-    const color = document.getElementById('shift-color').value;
-
-
-    // Legg turnus som uker
-    const shift = { 
-        name, 
-        workWeeks: durationArray[0], 
-        offWeeks: durationArray[1], 
-        startDate, 
-        color, 
-        visible: true 
-    };
-    shifts.push(shift);
-    renderShiftList();
-    renderCalendar(currentMonth, currentYear); // Oppdater kalenderen for å vise ny turnus
-});
-
 
 // Initialiser kalenderen
 renderCalendar(currentMonth, currentYear);


### PR DESCRIPTION
## Summary
- clean up DOMContentLoaded debug block
- rely on initializeEventListeners for `add-shift` handler
- remove unused custom add-shift handler
- use `maxShifts` constant when validating new shifts

## Testing
- `php -l backend/login.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684a01462bc4833389d97f0d041aac5f