### PR TITLE
Add reusable message component

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -152,6 +152,22 @@ h2 {
     font-weight: bold;
 }
 
+#message {
+    margin-top: 20px;
+    text-align: center;
+    color: #28203f;
+    font-weight: bold;
+    display: none;
+}
+
+#message.success {
+    color: green;
+}
+
+#message.error {
+    color: red;
+}
+
 /* Style for Beregne lønn siden */
 /* Custom styles for the calculator */
 .contact-box {

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
         <link rel="stylesheet" href="css/header.css">
         <link rel="stylesheet" href="css/calendar.css">
         <link rel="stylesheet" href="css/style.css">
+    <script defer src="js/message.js"></script>
     <script defer src="js/kalender.js"></script>
     <script defer src="js/session.js"></script>
 </head>
@@ -26,6 +27,7 @@
                 <li><a href="login.html" id="login-link">Logg inn</a></li>
             </ul>
         </nav>
+    <div id="message"></div>
     <!-- Kalender -->
     <div class="container">
         <div class="calendar-header">

--- a/js/kalender.js
+++ b/js/kalender.js
@@ -212,7 +212,7 @@ function addColorToDropdown(color) {
 // Funksjon for å legge til ny turnus
 function addNewShift() {
     if (shifts.length >= maxShifts) {
-        alert(`Maksimum antall turnuser er nådd. Slett en turnus for å legge til en ny.`);
+        showMessage(`Maksimum antall turnuser er nådd. Slett en turnus for å legge til en ny.`, 'error');
         return;
     }
 
@@ -226,7 +226,7 @@ function addNewShift() {
 
     
     if (!name || !durationInput || isNaN(startDate.getTime())) {
-        alert('Vennligst fyll inn alle feltene riktig.');
+        showMessage('Vennligst fyll inn alle feltene riktig.', 'error');
         return;
     }
 
@@ -234,7 +234,7 @@ function addNewShift() {
     if (durationInput === 'custom') {
         durationInput = prompt('Angi ønsket turnus i formatet "X-Y" for uker eller "D5-2" for dager:', '');
         if (!durationInput || !/^(\d+-\d+|D\d+-\d+)$/.test(durationInput)) {
-            alert('Ugyldig format. Bruk formatet "2-4" eller "D5-2".');
+            showMessage('Ugyldig format. Bruk formatet "2-4" eller "D5-2".', 'error');
             return;
         }
     }
@@ -250,7 +250,7 @@ function addNewShift() {
     }
 
     if (!workPeriod || !offPeriod || workPeriod <= 0 || offPeriod <= 0) {
-        alert('Ugyldig turnuslengde. Bruk formatet "2-4" eller "D5-2".');
+        showMessage('Ugyldig turnuslengde. Bruk formatet "2-4" eller "D5-2".', 'error');
         return;
     }
 
@@ -263,7 +263,7 @@ function addNewShift() {
     );
 
     if (isDuplicate) {
-        alert('Denne turnusen er allerede lagt til!');
+        showMessage('Denne turnusen er allerede lagt til!', 'error');
         return;
     }
 

--- a/js/login.js
+++ b/js/login.js
@@ -97,7 +97,7 @@ document.addEventListener('DOMContentLoaded', function () {
                         localStorage.setItem('userName', result.firstname);
                         window.location.href = 'index.html'; 
                     } else {
-                        alert('Innlogging feilet. Sjekk brukernavn og passord.');
+                        showMessage('Innlogging feilet. Sjekk brukernavn og passord.', 'error');
                     }
                     window.location.href = 'index.html'; // Gå til forsiden etter vellykket innlogging
                 }

--- a/js/message.js
+++ b/js/message.js
@@ -1,0 +1,17 @@
+function showMessage(text, type = 'info', timeout = 4000) {
+    const container = document.getElementById('message');
+    if (!container) {
+        alert(text);
+        return;
+    }
+
+    container.textContent = text;
+    container.className = type; // assign the type as class for styling
+    container.style.display = 'block';
+
+    if (timeout > 0) {
+        setTimeout(() => {
+            container.style.display = 'none';
+        }, timeout);
+    }
+}

--- a/js/user_profile.js
+++ b/js/user_profile.js
@@ -42,12 +42,12 @@ function fetchUserData() {
                 // Deaktiver feltene basert på NA-avkrysningsboksene
                 toggleInputField();
             } else {
-                alert(`Kunne ikke hente brukerdata: ${data.message}`);
+                showMessage(`Kunne ikke hente brukerdata: ${data.message}`, 'error');
             }
         })
         .catch(error => {
             console.error('Feil ved henting av data:', error);
-            alert('En feil oppstod ved henting av brukerdata.');
+            showMessage('En feil oppstod ved henting av brukerdata.', 'error');
         });
 }
 
@@ -73,7 +73,7 @@ function updateUserProfile() {
     const repeatPassword = document.getElementById('repeat-password').value; 
     
     if (newPassword && newPassword !== repeatPassword) {
-        alert("Passordene stemmer ikke overens.");
+        showMessage("Passordene stemmer ikke overens.", 'error');
         return; // Stopp innsendingen
     }
     
@@ -95,7 +95,7 @@ function updateUserProfile() {
     .then(data => {
         console.log('Server response:', data);
         if (data.status === 'success') {
-            alert('Profilen ble oppdatert!');
+            showMessage('Profilen ble oppdatert!', 'success');
 
             // Oppdater localStorage og header med nytt navn
             localStorage.setItem('userName', firstname);
@@ -104,12 +104,12 @@ function updateUserProfile() {
                 userInfoDiv.innerHTML = `<span>Velkommen, <a href="user_profile.html">${firstname}</a></span> | <a href="#" id="logout-btn">Logg ut</a>`;
             }
         } else {
-            alert(`Kunne ikke oppdatere profil: ${data.message}`);
+            showMessage(`Kunne ikke oppdatere profil: ${data.message}`, 'error');
         }
     })
     .catch(error => {
         console.error('Feil ved oppdatering:', error);
-        alert('Kunne ikke oppdatere profil.');
+        showMessage('Kunne ikke oppdatere profil.', 'error');
     });
 }
 

--- a/login.html
+++ b/login.html
@@ -6,6 +6,7 @@
     <title>Login - KalenderTurnus</title>
     <link rel="stylesheet" href="css/header.css">
     <link rel="stylesheet" href="css/style.css">
+    <script defer src="js/message.js"></script>
     <script defer src="js/session.js"></script>
     <script defer src="js/login.js"></script>
     <script defer src="js/forgot_password.js"></script>
@@ -27,6 +28,7 @@
                 <li><a href="login.html" id="login-link">Logg inn</a></li>
             </ul>
         </nav>
+    <div id="message"></div>
     <div class="login-box">
         <form id="form" data-action="login" method="post" novalidate>
             <h2>Logg inn</h2><br>

--- a/user_profile.html
+++ b/user_profile.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="css/header.css">
     <link rel="stylesheet" href="css/style.css">
     <link rel="stylesheet" href="css/user_profile.css">
+    <script defer src="js/message.js"></script>
     <script defer src="js/session.js"></script>
     <script defer src="js/user_profile.js"></script>
 </head>
@@ -26,6 +27,7 @@
             <li><a href="login.html" id="login-link">Logg inn</a></li>
         </ul>
     </nav>
+    <div id="message"></div>
         <div class="contact-box user-profile-box">
             <h2>Brukerprofil</h2>
             <form id="user-profile-form" novalidate>


### PR DESCRIPTION
## Summary
- create JS helper for showing messages
- style the new message container
- include the message container and script on pages using alerts
- replace alert() calls with `showMessage()` usage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a079f79508333ba52cfc5578a9fdd