### PR TITLE
Improve message placement and add double-click reset

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,6 @@
                 <li><a href="login.html" id="login-link">Logg inn</a></li>
             </ul>
         </nav>
-    <div id="message"></div>
     <!-- Kalender -->
     <div class="container">
         <div class="calendar-header">
@@ -91,6 +90,7 @@
         
         <button id="add-shift" class="btn">Legg til turnus</button>
         <button id="reset" class="btn-secondary">Tøm skjema</button>
+        <div id="message"></div>
     </div>
 
     <!-- Kolonnetitler for turnuslisten -->

--- a/js/kalender.js
+++ b/js/kalender.js
@@ -128,21 +128,34 @@ function initializeEventListeners() {
 }
 
 
-function resetShifts() {
-    // Bekreft at brukeren faktisk vil tømme alle turnusene
-    if (confirm("Er du sikker på at du vil tømme alle turnusene? Dette kan ikke angres.")) {
-        shifts = []; // Tømmer turnuslisten
-        saveShiftsToLocalStorage(); // Oppdaterer local storage med den tomme listen
-        // Tilbakestill tilgjengelige farger slik at alle farger blir synlige igjen
-        saveAvailableColors(Object.keys(colorLabels));
-        updateColorDropdown();
-        renderCalendar(currentMonth, currentYear); // Oppdaterer kalenderen
-        renderShiftList(); // Oppdaterer listen som viser turnuser
+let resetPending = false;
+let resetTimeout;
 
-        // Tøm oversikten under kalenderen
-        const oversiktContainer = document.getElementById('turnus-oversikt');
-        oversiktContainer.innerHTML = ''; // Fjern alt innhold
+function resetShifts() {
+    if (!resetPending) {
+        showMessage("Trykk på 'T\u00f8m skjema' igjen innen 10 sekunder for \u00e5 t\u00f8mme alle turnusene.");
+        resetPending = true;
+        resetTimeout = setTimeout(() => {
+            resetPending = false;
+        }, 10000);
+        return;
     }
+
+    resetPending = false;
+    clearTimeout(resetTimeout);
+
+    shifts = []; // Tømmer turnuslisten
+    saveShiftsToLocalStorage(); // Oppdaterer local storage med den tomme listen
+    // Tilbakestill tilgjengelige farger slik at alle farger blir synlige igjen
+    saveAvailableColors(Object.keys(colorLabels));
+    updateColorDropdown();
+    renderCalendar(currentMonth, currentYear); // Oppdaterer kalenderen
+    renderShiftList(); // Oppdaterer listen som viser turnuser
+
+    // Tøm oversikten under kalenderen
+    const oversiktContainer = document.getElementById('turnus-oversikt');
+    oversiktContainer.innerHTML = ''; // Fjern alt innhold
+    showMessage('Skjemaet ble t\u00f8mt.', 'success');
 }
 
 // Definer alle farger og deres etiketter

--- a/login.html
+++ b/login.html
@@ -28,7 +28,6 @@
                 <li><a href="login.html" id="login-link">Logg inn</a></li>
             </ul>
         </nav>
-    <div id="message"></div>
     <div class="login-box">
         <form id="form" data-action="login" method="post" novalidate>
             <h2>Logg inn</h2><br>
@@ -40,6 +39,7 @@
                 <input type="password" id="password" name="password" placeholder="Passord" required>
             </div>
             <button type="submit" class="btn">Logg inn</button>
+            <div id="message"></div>
             <button type="button" class="btn-secondary" id="reset-password-btn">Glemt passord?</button>
             <p>Har du ikke bruker? <a href="register.html">Registrer ny bruker</a></p>
         </form>

--- a/user_profile.html
+++ b/user_profile.html
@@ -27,7 +27,6 @@
             <li><a href="login.html" id="login-link">Logg inn</a></li>
         </ul>
     </nav>
-    <div id="message"></div>
         <div class="contact-box user-profile-box">
             <h2>Brukerprofil</h2>
             <form id="user-profile-form" novalidate>
@@ -99,6 +98,7 @@
                 </div>
 
                 <button type="submit" class="btn">Oppdater profil</button>
+                <div id="message"></div>
             </form>
         </div>
 </body>


### PR DESCRIPTION
## Summary
- move global `#message` containers into login, profile and calendar forms
- add message container under shift form buttons
- implement two-click reset action with a 10-second timeout

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a0ec36a608333b9c22f8199cd4b87