### PR TITLE
Implement redesigned user profile page

### DIFF
--- a/user_profile.html
+++ b/user_profile.html
@@ -27,56 +27,62 @@
             <li><a href="login.html" id="login-link">Logg inn</a></li>
         </ul>
     </nav>
-        <div class="contact-box user-profile-box">
+
+    <div class="contact-box user-profile-box">
+        <form id="user-profile-form" class="user-profile" novalidate>
             <h2>Brukerprofil</h2>
-            <form id="user-profile-form" novalidate>
-                <div class="profile-card">
-                    <div class="avatar-section">
-                        <div id="avatar-preview" class="avatar-img">👤</div>
-                        <input type="file" id="avatar" name="avatar" accept="image/*">
-                        <button type="button" id="avatar-remove" class="btn-secondary">Slett bilde</button>
+
+            <section class="profile-section">
+                <div class="avatar-section">
+                    <div id="avatar-preview" class="avatar-img">
+                        <img id="avatar-image" alt="Profilbilde" />
                     </div>
-                    <div class="name-section">
-                        <div class="form-group user-profile-group">
-                            <label for="first-name">Fornavn:</label>
-                            <input type="text" id="first-name" name="first-name" placeholder="Fornavn" required>
-                        </div>
-                        <div class="form-group user-profile-group">
-                            <label for="last-name">Etternavn:</label>
-                            <input type="text" id="last-name" name="last-name" placeholder="Etternavn" required>
-                        </div>
+                    <input type="file" id="avatar-upload" name="avatar-upload" accept="image/*">
+                    <button type="button" id="avatar-remove" class="btn-secondary">Slett bilde</button>
+                </div>
+                <div class="name-section">
+                    <div class="form-group">
+                        <label for="first-name">Fornavn</label>
+                        <input type="text" id="first-name" name="first-name" placeholder="Fornavn" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="last-name">Etternavn</label>
+                        <input type="text" id="last-name" name="last-name" placeholder="Etternavn" required>
                     </div>
                 </div>
+            </section>
 
-                <div class="form-group user-profile-group">
-                    <label for="email">E-post:</label>
-                    <input type="email" id="email" name="email" placeholder="E-post" disabled>
-                    <a href="change_password.html" class="password-link">Endre passord</a>
+            <section class="account-section">
+                <div class="form-group">
+                    <label for="email">E-post</label>
+                    <input type="email" id="email" name="email" readonly>
                 </div>
+                <a href="reset_password.html" class="btn-secondary">Endre passord</a>
+            </section>
 
-                <div class="form-group user-profile-group section-divider">
-                    <label for="company">Firma:</label>
-                    <input type="text" id="company" name="company" placeholder="Firma">
+            <section class="work-section">
+                <div class="info-row">
+                    <label for="company">Firma</label>
+                    <input type="text" id="company" name="company">
                     <div class="options-inline">
                         <label><input type="checkbox" id="company-hide"> Skjul</label>
                         <label><input type="checkbox" id="company-na"> NA</label>
                     </div>
-                    <p class="description">Velg firma, eller velg "skjul" for ikke å vise dette på profilen din.</p>
                 </div>
 
-                <div class="form-group user-profile-group">
-                    <label for="location">Lokasjon:</label>
-                    <input type="text" id="location" name="location" placeholder="Lokasjon">
+                <div class="info-row">
+                    <label for="location">Lokasjon</label>
+                    <input type="text" id="location" name="location">
                     <div class="options-inline">
                         <label><input type="checkbox" id="location-hide"> Skjul</label>
                         <label><input type="checkbox" id="location-na"> NA</label>
                     </div>
-                    <p class="description">Skriv inn din lokasjon, eller velg "skjul" eller "NA" om ønskelig.</p>
                 </div>
 
-                <div class="form-group user-profile-group">
-                    <label for="shift">Turnus:</label>
+                <div class="info-row">
+                    <label for="shift">Turnus</label>
                     <select id="shift" name="shift">
+                        <option value="">Velg...</option>
                         <option value="mandag-fredag">Mandag til fredag</option>
                         <option value="1-2">1-2</option>
                         <option value="1-3">1-3</option>
@@ -96,18 +102,29 @@
                         <label><input type="checkbox" id="shift-hide"> Skjul</label>
                         <label><input type="checkbox" id="shift-na"> NA</label>
                     </div>
-                    <p class="description">Velg din turnus. Hvis du ikke ønsker å vise dette, kan du velge "skjul".</p>
                 </div>
 
-                <div class="form-group user-profile-group">
-                    <label for="first-shift">Første skift:</label>
+                <div class="info-row">
+                    <label for="first-shift">Første skift</label>
                     <input type="date" id="first-shift" name="first-shift">
+                    <div class="options-inline">
+                        <label><input type="checkbox" id="first-shift-hide"> Skjul</label>
+                        <label><input type="checkbox" id="first-shift-na"> NA</label>
+                    </div>
                 </div>
+            </section>
 
-                <button type="submit" class="btn">Oppdater profil</button>
-                <button type="button" id="preview-btn" class="btn-secondary">Forhåndsvis</button>
-                <div id="message"></div>
-            </form>
+            <button type="submit" class="btn">Oppdater profil</button>
+            <button type="button" id="preview-btn" class="btn-secondary">Forhåndsvis</button>
+            <div id="message"></div>
+        </form>
+    </div>
+
+    <div id="preview-modal" class="modal" style="display:none;">
+        <div class="modal-content">
+            <span id="modal-close" class="close">&times;</span>
+            <div id="preview-content"></div>
         </div>
+    </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- overhaul `user_profile.html` layout
- add sections for avatar, personal data and work information
- include hide/NA options for all info rows
- prepare modal preview element for future use

## Testing
- `npm test` *(fails: package.json not found)*
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b510923a083339fc7aab3b3e40e18