### PR TITLE
Enhance color picker options

### DIFF
--- a/css/calendar.css
+++ b/css/calendar.css
@@ -356,4 +356,9 @@
     }
 }
 
+/* Ensure dropdown text is readable over colored backgrounds */
+option {
+    color: #000;
+}
+
 

--- a/index.html
+++ b/index.html
@@ -78,16 +78,16 @@
         
         <label for="shift-color">Velg farge:</label>
         <select id="shift-color">
-            <option value="#FF6666">Rød</option>
-            <option value="#FFB266">Oransje</option>
-            <option value="#FFFF66">Gul</option>
-            <option value="#B2FF66">Lys Grønn</option>
-            <option value="#66FFB2">Turkis</option>
-            <option value="#66B2FF">Lys Blå</option>
-            <option value="#FF66B2">Rosa</option>
-            <option value="#CC66FF">Fiolett</option>
-            <option value="#66FF66">Grønn</option>
-            <option value="#CCCCCC">Lys Grå</option>
+            <option value="#FF6666" style="background-color:#FF6666;">Rød</option>
+            <option value="#FFB266" style="background-color:#FFB266;">Oransje</option>
+            <option value="#FFFF66" style="background-color:#FFFF66;">Gul</option>
+            <option value="#B2FF66" style="background-color:#B2FF66;">Lys Grønn</option>
+            <option value="#66FFB2" style="background-color:#66FFB2;">Turkis</option>
+            <option value="#66B2FF" style="background-color:#66B2FF;">Lys Blå</option>
+            <option value="#FF66B2" style="background-color:#FF66B2;">Rosa</option>
+            <option value="#CC66FF" style="background-color:#CC66FF;">Fiolett</option>
+            <option value="#66FF66" style="background-color:#66FF66;">Grønn</option>
+            <option value="#CCCCCC" style="background-color:#CCCCCC;">Lys Grå</option>
         </select>
         
         <button id="add-shift" class="btn">Legg til turnus</button>


### PR DESCRIPTION
## Summary
- apply inline background colors to the color dropdown options
- ensure options are legible by forcing black text in calendar.css

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684efa9dd0888333b851669885208937