### PR TITLE
Highlight current day in calendar

### DIFF
--- a/js/kalender.js
+++ b/js/kalender.js
@@ -480,6 +480,14 @@ function renderCalendar(month, year) {
         dayElement.appendChild(shiftContainer);
 
         const date = new Date(year, month, day);
+
+        if (
+            date.getFullYear() === currentDate.getFullYear() &&
+            date.getMonth() === currentDate.getMonth() &&
+            date.getDate() === currentDate.getDate()
+        ) {
+            dayElement.classList.add('today');
+        }
         
         // Sjekk om dagen er en rød dag
         const redDay = getRedDayInfo(date);


### PR DESCRIPTION
## Summary
- show the current day when rendering the calendar

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684efa40f8f48333beef1017c20093d4