### PR TITLE
Verify session state on load

### DIFF
--- a/js/login.js
+++ b/js/login.js
@@ -1,41 +1,8 @@
 document.addEventListener('DOMContentLoaded', function () {
-    // Hent nødvendige elementer
-    const userName = localStorage.getItem('userName');
-    const userInfoDiv = document.getElementById('user-info');
-    const friendsLink = document.getElementById('friends-link');
-    const loginLink = document.getElementById('login-link');
     const hamburger = document.getElementById('hamburger');
     const navbar = document.getElementById('navbar');
     const form = document.getElementById('form');
-    const logoutBtn = document.getElementById('logout-btn');
     const resetPasswordBtn = document.getElementById('reset-password-btn');
-
-    // Håndter innloggingsstatus
-    if (userName) {
-        // Oppdater header for å vise velkomstmelding og logg ut-knapp
-        if (userInfoDiv) {
-            userInfoDiv.innerHTML = `<span>Velkommen, <a href="user_profile.html">${userName}</a></span> | <a href="#" id="logout-btn">Logg ut</a>`;
-        }
-
-        // Vis venne- og lønnstabell-lenker hvis brukeren er logget inn
-        if (friendsLink) friendsLink.style.display = 'inline';
-
-        // Skjul "Logg inn"-lenken når brukeren er logget inn
-        if (loginLink) loginLink.style.display = 'none';
-
-        // Håndter utlogging
-        document.addEventListener('click', function (event) {
-            if (event.target && event.target.id === 'logout-btn') {
-                if (confirm("Er du sikker på at du vil logge ut?")) {
-                    localStorage.removeItem('userName');
-                    window.location.href = 'index.html';
-                }
-            }
-        });
-    } else {
-        // Hvis brukeren IKKE er logget inn, fjern venne- og lønnstabell-lenker
-        if (friendsLink) friendsLink.style.display = 'none';
-    }
 
     // Håndter navigasjon for hamburgermenyen
     if (hamburger && navbar) {

--- a/js/session.js
+++ b/js/session.js
@@ -1,49 +1,57 @@
-document.addEventListener('DOMContentLoaded', function () {
-    const userName = localStorage.getItem('userName');
+document.addEventListener('DOMContentLoaded', async () => {
     const userInfoDiv = document.getElementById('user-info');
     const friendsLink = document.getElementById('friends-link');
     const loginLink = document.getElementById('login-link');
+    const hamburger = document.getElementById('hamburger');
+    const navbar = document.getElementById('navbar');
 
-    // Håndter innloggingsstatus
-    if (userName) {
-        // Oppdater header for å vise velkomstmelding og logg ut-knapp
-        if (userInfoDiv) {
-            userInfoDiv.innerHTML = `<span>Velkommen, <a href="user_profile.html"><strong>${userName}</strong></a></span> | <a href="#" id="logout-btn">Logg ut</a>`;
+    let userName = null;
+    try {
+        const resp = await fetch('backend/session_status.php', { credentials: 'include' });
+        if (resp.ok) {
+            const data = await resp.json();
+            if (data.loggedIn) {
+                userName = data.userName;
+                localStorage.setItem('userName', userName);
+            } else {
+                localStorage.removeItem('userName');
+            }
+        } else {
+            userName = localStorage.getItem('userName');
         }
-
-        // Vis venne-lenken hvis brukeren er logget inn
-        if (friendsLink) friendsLink.style.display = 'list-item';
-
-        // Skjul "Logg inn"-lenken når brukeren er logget inn
-        if (loginLink) {
-            loginLink.style.display = 'none';
-        }
-
-    } else {
-        // Skjul venne-lenken hvis brukeren ikke er logget inn
-        if (friendsLink) friendsLink.style.display = 'none';
-
-        // Sørg for at "Logg inn"-lenken vises
-        if (loginLink) loginLink.style.display = 'list-item';
+    } catch (err) {
+        console.error('Failed to check session status', err);
+        userName = localStorage.getItem('userName');
     }
 
-    // Global event listener for utlogging
+    renderHeader(userName);
+    document.dispatchEvent(new CustomEvent('session-verified', { detail: { loggedIn: !!userName, userName } }));
+
     document.addEventListener('click', function (event) {
         if (event.target && event.target.id === 'logout-btn') {
             if (confirm("Er du sikker på at du vil logge ut?")) {
-                localStorage.removeItem('userName'); // Fjern brukernavn fra localStorage
-                window.location.href = 'index.html'; // Gå tilbake til hovedsiden
+                localStorage.removeItem('userName');
+                window.location.href = 'index.html';
             }
         }
     });
 
-    // Håndter navigasjon for hamburgermenyen
-    const hamburger = document.getElementById('hamburger');
-    const navbar = document.getElementById('navbar');
-
     if (hamburger && navbar) {
         hamburger.addEventListener('click', function () {
-            navbar.classList.toggle('show'); // Vis/skjul navigasjonen ved å toggle 'show'-klassen
+            navbar.classList.toggle('show');
         });
+    }
+
+    function renderHeader(name) {
+        if (name) {
+            if (userInfoDiv) {
+                userInfoDiv.innerHTML = `<span>Velkommen, <a href="user_profile.html"><strong>${name}</strong></a></span> | <a href="#" id="logout-btn">Logg ut</a>`;
+            }
+            if (friendsLink) friendsLink.style.display = 'list-item';
+            if (loginLink) loginLink.style.display = 'none';
+        } else {
+            if (friendsLink) friendsLink.style.display = 'none';
+            if (loginLink) loginLink.style.display = 'list-item';
+        }
     }
 });

--- a/js/user_profile.js
+++ b/js/user_profile.js
@@ -1,5 +1,10 @@
+document.addEventListener('session-verified', (e) => {
+    if (e.detail.loggedIn) {
+        fetchUserData();
+    }
+});
+
 document.addEventListener('DOMContentLoaded', function () {
-    fetchUserData();
 
     const profileForm = document.getElementById('user-profile-form');
     if (profileForm) {


### PR DESCRIPTION
## Summary
- check `session_status.php` on page load
- update header based on verified status
- defer user data loading in `user_profile.js` until session verified
- remove duplicate header logic from `login.js`

## Testing
- `npm test` *(fails: ENOENT could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684efffcf2348333b18d13d54148d98c