### PR TITLE
Implement profile deletion

### DIFF
--- a/backend/delete_profile.php
+++ b/backend/delete_profile.php
@@ -1,0 +1,38 @@
+<?php
+session_start();
+header('Content-Type: application/json');
+require_once 'database.php';
+
+if (!isset($_SESSION['user_id'])) {
+    http_response_code(401);
+    echo json_encode(['status' => 'error', 'message' => 'Ikke innlogget']);
+    exit;
+}
+
+$userId = (int)$_SESSION['user_id'];
+
+try {
+    // Slett relasjoner i friend_requests
+    $stmt = $conn->prepare('DELETE FROM friend_requests WHERE sender_id = ? OR receiver_id = ?');
+    $stmt->bind_param('ii', $userId, $userId);
+    $stmt->execute();
+    $stmt->close();
+
+    // Slett relasjoner i friends
+    $stmt = $conn->prepare('DELETE FROM friends WHERE user1 = ? OR user2 = ?');
+    $stmt->bind_param('ii', $userId, $userId);
+    $stmt->execute();
+    $stmt->close();
+
+    // Slett brukeren
+    $stmt = $conn->prepare('DELETE FROM users WHERE id = ?');
+    $stmt->bind_param('i', $userId);
+    $stmt->execute();
+    $stmt->close();
+
+    session_destroy();
+    echo json_encode(['status' => 'success']);
+} catch (Exception $e) {
+    http_response_code(500);
+    echo json_encode(['status' => 'error', 'message' => 'Databasefeil']);
+}

--- a/css/user_profile.css
+++ b/css/user_profile.css
@@ -91,6 +91,15 @@
 #preview-btn {
     margin-top: 10px;
 }
+
+#delete-profile-btn {
+    margin-top: 10px;
+    background-color: #e74c3c;
+    color: #fff;
+}
+#delete-profile-btn:hover {
+    background-color: #c0392b;
+}
 @media (max-width: 600px) {
     .profile-card {
         flex-direction: column;

--- a/js/user_profile.js
+++ b/js/user_profile.js
@@ -1,3 +1,6 @@
+let deletePending = false;
+let deleteTimeout;
+
 document.addEventListener('DOMContentLoaded', function () {
     fetchUserData();
 
@@ -48,6 +51,11 @@ document.addEventListener('DOMContentLoaded', function () {
     const previewBtn = document.getElementById('preview-btn');
     if (previewBtn) {
         previewBtn.addEventListener('click', showPreview);
+    }
+
+    const deleteBtn = document.getElementById('delete-profile-btn');
+    if (deleteBtn) {
+        deleteBtn.addEventListener('click', deleteProfile);
     }
 
     addToggleListeners();
@@ -182,6 +190,33 @@ function showPreview() {
     window.onclick = function(event) {
         if (event.target === modal) modal.style.display = 'none';
     };
+}
+
+function deleteProfile() {
+    if (!deletePending) {
+        showMessage("Trykk på 'Slett profil' igjen innen 10 sekunder for å bekrefte.");
+        deletePending = true;
+        deleteTimeout = setTimeout(() => { deletePending = false; }, 10000);
+        return;
+    }
+
+    deletePending = false;
+    clearTimeout(deleteTimeout);
+
+    fetch('backend/delete_profile.php', {
+        method: 'POST',
+        credentials: 'include'
+    })
+    .then(r => r.json())
+    .then(data => {
+        if (data.status === 'success') {
+            localStorage.removeItem('userName');
+            window.location.href = 'login.html';
+        } else {
+            showMessage('Kunne ikke slette profil.', 'error');
+        }
+    })
+    .catch(() => showMessage('Kunne ikke slette profil.', 'error'));
 }
 
 

--- a/user_profile.html
+++ b/user_profile.html
@@ -118,6 +118,7 @@
 
             <button type="submit" class="btn">Oppdater profil</button>
             <button type="button" id="preview-btn" class="btn-secondary">Forhåndsvis</button>
+            <button type="button" id="delete-profile-btn" class="btn-secondary">Slett profil</button>
             <div id="message"></div>
         </form>
     </div>


### PR DESCRIPTION
## Summary
- allow users to delete their account via `delete_profile.php`
- add "Slett profil" button to the profile page
- handle deletion logic in `user_profile.js`
- style the delete button

## Testing
- `php -l backend/delete_profile.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f0002b67c833396bc273dfb8d58b0