### PR TITLE
Handle blank shift_date

### DIFF
--- a/backend/update_profile.php
+++ b/backend/update_profile.php
@@ -29,6 +29,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $shiftHide = isset($_POST['shift-hide']) ? 1 : 0;
         $shiftNa = isset($_POST['shift-na']) ? 1 : 0;
         $shiftDate = $_POST['shift_date'] ?? null;
+        if ($shiftDate === '') {
+            $shiftDate = null; // allow empty date field
+        }
 
         $avatarUrl = null;
         if (isset($_FILES['avatar']) && $_FILES['avatar']['error'] === UPLOAD_ERR_OK) {


### PR DESCRIPTION
## Summary
- allow empty `shift_date` values in `update_profile.php`

## Testing
- `php -l backend/update_profile.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f03e367c0833398fa7f251c0c3a51