### PR TITLE
Add schema for friends tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,27 @@ All endpoints require the user to be logged in via PHP sessions.
 
 These scripts expect the tables `friend_requests` and `friends` in the database
 as described in `js/friends.js`.
+
+### Creating the friends tables
+
+You can create the required tables manually or import the provided
+`schema.sql` file using phpMyAdmin's **Import** feature. The SQL definition is
+shown below:
+
+```sql
+CREATE TABLE `friend_requests` (
+  `id` INT AUTO_INCREMENT PRIMARY KEY,
+  `sender_id` INT NOT NULL,
+  `receiver_id` INT NOT NULL,
+  `status` TINYINT NOT NULL DEFAULT 0,
+  `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  KEY `sender_id` (`sender_id`),
+  KEY `receiver_id` (`receiver_id`)
+);
+
+CREATE TABLE `friends` (
+  `user1` INT NOT NULL,
+  `user2` INT NOT NULL,
+  PRIMARY KEY (`user1`, `user2`)
+);
+```

--- a/schema.sql
+++ b/schema.sql
@@ -1,0 +1,19 @@
+-- SQL schema for KalenderTurnus friendship features
+
+-- Table storing pending colleague requests
+CREATE TABLE `friend_requests` (
+  `id` INT AUTO_INCREMENT PRIMARY KEY,
+  `sender_id` INT NOT NULL,
+  `receiver_id` INT NOT NULL,
+  `status` TINYINT NOT NULL DEFAULT 0,
+  `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  KEY `sender_id` (`sender_id`),
+  KEY `receiver_id` (`receiver_id`)
+);
+
+-- Table storing confirmed colleague relations
+CREATE TABLE `friends` (
+  `user1` INT NOT NULL,
+  `user2` INT NOT NULL,
+  PRIMARY KEY (`user1`, `user2`)
+);


### PR DESCRIPTION
## Summary
- document SQL for `friend_requests` and `friends`
- provide a `schema.sql` that can be imported in phpMyAdmin

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f3fbb48f08333b4d799a40e192f32