### PR TITLE
Improve colleague page UX

### DIFF
--- a/api/user_info.php
+++ b/api/user_info.php
@@ -1,0 +1,36 @@
+<?php
+session_start();
+header('Content-Type: application/json');
+require_once __DIR__ . '/../backend/database.php';
+
+if (!isset($_SESSION['user_id'])) {
+    http_response_code(401);
+    echo json_encode(['status' => 'error', 'message' => 'Ikke innlogget']);
+    exit;
+}
+
+$id = isset($_GET['id']) ? intval($_GET['id']) : 0;
+if ($id <= 0) {
+    http_response_code(400);
+    echo json_encode(['status' => 'error', 'message' => 'Ugyldig ID']);
+    exit;
+}
+
+$sql = "SELECT firstname, lastname, avatar_url, company, company_hidden, location, location_hidden, shift, shift_hidden, shift_date FROM users WHERE id=?";
+$stmt = $conn->prepare($sql);
+$stmt->bind_param('i', $id);
+$stmt->execute();
+$res = $stmt->get_result();
+if ($row = $res->fetch_assoc()) {
+    if ($row['company_hidden']) $row['company'] = null;
+    if ($row['location_hidden']) $row['location'] = null;
+    if ($row['shift_hidden']) {
+        $row['shift'] = null;
+        $row['shift_date'] = null;
+    }
+    unset($row['company_hidden'], $row['location_hidden'], $row['shift_hidden']);
+    echo json_encode(['status' => 'success', 'user' => $row]);
+} else {
+    http_response_code(404);
+    echo json_encode(['status' => 'error', 'message' => 'Ikke funnet']);
+}

--- a/css/friends.css
+++ b/css/friends.css
@@ -9,6 +9,22 @@
     margin-bottom: 20px;
 }
 
+.search-section button {
+    padding: 10px 20px;
+    border: none;
+    background: var(--primary-color);
+    color: var(--light-color);
+    border-radius: 8px;
+    cursor: pointer;
+}
+
+.requests-section,
+.colleagues-section {
+    margin-top: 30px;
+    padding-bottom: 20px;
+    border-bottom: 1px solid var(--secondary-color);
+}
+
 #search-input {
     flex: 1;
     padding: 10px;

--- a/friends.html
+++ b/friends.html
@@ -30,6 +30,7 @@
 </nav>
 
 <div class="contact-box friends-page">
+    <h2>Kollegaer</h2>
     <!-- Søkeseksjon -->
     <section class="search-section">
         <input type="text" id="search-input" placeholder="Søk etter navn">
@@ -39,17 +40,21 @@
 
     <!-- Forespørsler-seksjon -->
     <section class="requests-section">
-        <h3>Ventende forespørsler</h3>
+        <h3>Ventende kollegaforespørsel</h3>
         <div id="pending-requests"></div>
-        <h3>Sendte forespørsler</h3>
-        <div id="sent-requests"></div>
     </section>
 
     <!-- Kollegaoversikt -->
     <section class="colleagues-section">
-        <h3>Mine kollegaer</h3>
+        <h3>Mine kollegaer (<span id="colleague-count">0</span>)</h3>
         <div id="colleagues-list" class="colleagues-grid"></div>
     </section>
+    <div id="colleague-modal" class="modal">
+        <div class="modal-content">
+            <span id="colleague-close" class="close">&times;</span>
+            <div id="colleague-content"></div>
+        </div>
+    </div>
 </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- redesign friends page layout
- remove sent requests section and rename to pending colleague requests
- allow searching with Enter key
- display colleague count and show profile details in a modal
- style sections and search button
- add API endpoint to fetch user info

## Testing
- `php -l api/user_info.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684fb45f9c9c8333a1b3186576e09fd8