### PR TITLE
Fix info visibility update

### DIFF
--- a/backend/update_profile.php
+++ b/backend/update_profile.php
@@ -22,7 +22,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $company = $_POST['company'] ?? '';
         $location = $_POST['location'] ?? '';
         $shift = $_POST['shift'] ?? '';
-        $infoHide = isset($_POST['info-hide']) ? 1 : 0;
+        // "info-hide" kommer alltid med i POST-data. Vi må derfor se på
+        // verdien, ikke bare om feltet eksisterer, ellers blir verdien alltid 1.
+        $infoHide = (isset($_POST['info-hide']) && $_POST['info-hide'] === '1') ? 1 : 0;
         $shiftDate = $_POST['shift_date'] ?? null;
         if ($shiftDate === '') {
             $shiftDate = null; // allow empty date field


### PR DESCRIPTION
## Summary
- ensure `info-hide` value is properly stored when updating user profiles

## Testing
- `php -l backend/update_profile.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684fcdc83880833394b1447835838453