### PR TITLE
Add colleague shift selection

### DIFF
--- a/api/my_colleagues.php
+++ b/api/my_colleagues.php
@@ -10,7 +10,8 @@ if (!isset($_SESSION['user_id'])) {
 }
 
 $uid = $_SESSION['user_id'];
-$sql = "SELECT u.id, u.firstname, u.lastname, u.avatar_url, u.company, u.location, u.shift
+$sql = "SELECT u.id, u.firstname, u.lastname, u.avatar_url,
+        u.company, u.location, u.shift, u.shift_date, u.info_hide
         FROM friends f
         JOIN users u ON (u.id = IF(f.user1 = ?, f.user2, f.user1))
         WHERE f.user1 = ? OR f.user2 = ?";
@@ -20,6 +21,12 @@ $stmt->execute();
 $result = $stmt->get_result();
 $list = [];
 while ($row = $result->fetch_assoc()) {
+    if ($row['info_hide']) {
+        $row['company'] = null;
+        $row['location'] = null;
+        $row['shift'] = null;
+        $row['shift_date'] = null;
+    }
     $list[] = $row;
 }
 

--- a/css/calendar.css
+++ b/css/calendar.css
@@ -371,4 +371,31 @@ option {
     color: #000;
 }
 
+/* Kollegaseksjon under kalenderen */
+.colleague-section {
+    margin-top: 20px;
+}
+
+#colleague-search {
+    width: 100%;
+    padding: 8px;
+    margin-bottom: 10px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+}
+
+.colleague-item {
+    display: flex;
+    align-items: center;
+    padding: 5px 0;
+}
+
+.colleague-item label {
+    flex: 1;
+}
+
+.colleague-item input[type="checkbox"] {
+    margin-right: 10px;
+}
+
 

--- a/index.html
+++ b/index.html
@@ -107,6 +107,12 @@
 
     <!-- Liste over aktive turnuser med mulighet for sletting og skjuling -->
     <div id="shift-list" class="shift-list"></div>
+
+    <div class="colleague-section">
+        <h3>Kollegaskift</h3>
+        <input type="text" id="colleague-search" placeholder="Søk kollega">
+        <div id="colleague-list" class="colleague-list"></div>
+    </div>
 </div>
 
 


### PR DESCRIPTION
## Summary
- allow fetching colleagues' shift with info_hide control
- add colleague toggle list in the calendar page
- style colleague selector
- store colleague selections in localStorage
- keep colleagues when clearing calendar

## Testing
- `node --check js/kalender.js`

------
https://chatgpt.com/codex/tasks/task_e_684fed3af1a88333a9c0cf03fd443e84