### PR TITLE
Improve colleague shift UI

### DIFF
--- a/css/calendar.css
+++ b/css/calendar.css
@@ -373,7 +373,10 @@ option {
 
 /* Kollegaseksjon under kalenderen */
 .colleague-section {
-    margin-top: 20px;
+    margin: 20px 0;
+    padding: 15px;
+    border: 1px solid #ddd;
+    border-radius: 8px;
 }
 
 #colleague-search {
@@ -388,10 +391,16 @@ option {
     display: flex;
     align-items: center;
     padding: 5px 0;
+    font-size: 0.9rem;
 }
 
 .colleague-item label {
     flex: 1;
+    cursor: pointer;
+}
+
+.colleague-name:hover {
+    text-decoration: underline;
 }
 
 .colleague-item input[type="checkbox"] {

--- a/index.html
+++ b/index.html
@@ -49,8 +49,15 @@
         </div>
         <div class="calendar-grid"></div>
         <div id="turnus-oversikt" class="turnus-oversikt"></div>
+
+        <div class="colleague-section">
+            <h3>Kollegaskift</h3>
+            <input type="text" id="colleague-search" placeholder="Søk kollega">
+            <div id="colleague-list" class="colleague-list"></div>
+        </div>
+
     <div class="shift-form">
-        <h3>Legg til ny turnus</h3>
+        <h3>Legg til ny turnus manuelt</h3>
         
         <label for="shift-name">Navn på turnus:</label>
         <input type="text" id="shift-name" placeholder="Eks: Thomas">
@@ -108,10 +115,12 @@
     <!-- Liste over aktive turnuser med mulighet for sletting og skjuling -->
     <div id="shift-list" class="shift-list"></div>
 
-    <div class="colleague-section">
-        <h3>Kollegaskift</h3>
-        <input type="text" id="colleague-search" placeholder="Søk kollega">
-        <div id="colleague-list" class="colleague-list"></div>
+</div>
+
+<div id="colleague-modal" class="modal">
+    <div class="modal-content">
+        <span id="colleague-close" class="close">&times;</span>
+        <div id="colleague-content"></div>
     </div>
 </div>
 

--- a/js/kalender.js
+++ b/js/kalender.js
@@ -420,6 +420,8 @@ function renderColleagueList(filter = '') {
             cb.addEventListener('change', () => toggleColleagueSelection(c.id, cb.checked));
             const label = document.createElement('label');
             label.textContent = `${c.firstname} ${c.lastname}`.trim();
+            label.className = 'colleague-name';
+            label.addEventListener('click', () => showColleagueCard(c.id));
             item.appendChild(cb);
             item.appendChild(label);
             list.appendChild(item);
@@ -428,6 +430,35 @@ function renderColleagueList(filter = '') {
     if (search && !search.oninput) {
         search.addEventListener('input', e => renderColleagueList(e.target.value));
     }
+}
+
+function showColleagueCard(id) {
+    fetch(`api/user_info.php?id=${id}`, { credentials: 'include' })
+        .then(r => r.json())
+        .then(data => {
+            if (!data || data.status !== 'success') return;
+            const modal = document.getElementById('colleague-modal');
+            const content = document.getElementById('colleague-content');
+            const u = data.user;
+            let html = '<div class="user-card">';
+            if (u.avatar_url) {
+                html += `<div class="avatar-img" style="background-image:url('${u.avatar_url}')"></div>`;
+            } else {
+                html += '<div class="avatar-img">👤</div>';
+            }
+            html += '<div class="user-info">';
+            const name = `${u.firstname || ''} ${u.lastname || ''}`.trim() || (u.fullname || '');
+            html += `<p class="name"><strong>${name}</strong></p>`;
+            if (u.company) html += `<p>${u.company}</p>`;
+            if (u.location) html += `<p>${u.location}</p>`;
+            if (u.shift) html += `<p>${u.shift}</p>`;
+            html += '</div></div>';
+            content.innerHTML = html;
+            modal.style.display = 'block';
+            const closeBtn = document.getElementById('colleague-close');
+            if (closeBtn) closeBtn.onclick = () => { modal.style.display = 'none'; };
+            window.onclick = function(e) { if (e.target === modal) modal.style.display = 'none'; };
+        });
 }
 
 function toggleColleagueSelection(id, checked) {


### PR DESCRIPTION
## Summary
- move colleague shift section above shift form
- rename shift form heading
- style colleague section to match form
- add modal for colleague details
- allow clicking colleague name to view profile card

## Testing
- `node --check js/kalender.js`

------
https://chatgpt.com/codex/tasks/task_e_684ff36136508333bef6539bbd1dfa61