### PR TITLE
Adjust colleague display and user shift toggle

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -307,10 +307,16 @@ a:hover {
 /* Toggle for user shift in calendar */
 .user-shift-toggle {
     margin: 10px 0;
+    display: flex;
+    align-items: center;
 }
 .user-shift-toggle label {
+    flex: 1;
     cursor: pointer;
     font-weight: bold;
+}
+.user-shift-toggle input[type="checkbox"] {
+    margin-right: 10px;
 }
 
 /* Kortdesign for brukere */

--- a/index.html
+++ b/index.html
@@ -35,9 +35,6 @@
             <h2 id="month-year">Oktober 2024</h2>
             <button id="next-month" class="nav-button">Neste →</button>
         </div>
-        <div id="user-shift-toggle" class="user-shift-toggle" style="display:none;">
-            <label><input type="checkbox" id="show-user-shift"> <span id="user-shift-label"></span></label>
-        </div>
         <div class="weekday-row">
             <div class="weekday">MON</div>
             <div class="weekday">TIR</div>
@@ -52,6 +49,9 @@
 
         <div class="colleague-section">
             <h3>Kollegaskift</h3>
+            <div id="user-shift-toggle" class="user-shift-toggle" style="display:none;">
+                <label><input type="checkbox" id="show-user-shift"> <span id="user-shift-label"></span></label>
+            </div>
             <input type="text" id="colleague-search" placeholder="Søk kollega">
             <div id="colleague-list" class="colleague-list"></div>
         </div>

--- a/js/kalender.js
+++ b/js/kalender.js
@@ -16,6 +16,7 @@ let userShift = null;
 let colleagues = [];
 let selectedColleagues = [];
 let colleagueColorPref = {};
+let currentUserFirstName = '';
 const allColors = [
   "#FF6666", "#FFB266", "#FFFF66", "#B2FF66", "#66FFB2",
   "#66B2FF", "#CC66FF", "#FF66B2", "#66FF66", "#CCCCCC",
@@ -346,6 +347,7 @@ function renderColleagueList(filter = '') {
     const term = filter.toLowerCase();
     colleagues
         .filter(c => (`${c.firstname} ${c.lastname}`.trim()).toLowerCase().includes(term))
+        .sort((a, b) => `${a.firstname} ${a.lastname}`.localeCompare(`${b.firstname} ${b.lastname}`))
         .forEach(c => {
             const item = document.createElement('div');
             item.className = 'colleague-item';
@@ -451,6 +453,7 @@ function loadUserShift() {
             const [work, off] = data.user.shift.split('-').map(Number);
             const startDate = new Date(data.user.shift_date + 'T00:00:00');
             const pref = localStorage.getItem('userColor');
+            currentUserFirstName = data.user.firstname || '';
             userShift = {
                 name: `${data.user.firstname} ${data.user.lastname}`.trim(),
                 workWeeks: work,
@@ -467,7 +470,7 @@ function loadUserShift() {
             updateTurnusOversikt();
 
             if (label && checkbox && toggleDiv) {
-                label.textContent = `${userShift.name} (${data.user.shift})`;
+                label.textContent = `${userShift.name} (meg)`;
                 checkbox.checked = userShift.visible;
                 toggleDiv.style.display = 'block';
                 checkbox.addEventListener('change', () => {
@@ -495,7 +498,8 @@ function updateTurnusOversikt() {
         colorBox.style.backgroundColor = shift.color;
 
         const nameText = document.createElement('span');
-        nameText.textContent = `${shift.name} (${shift.workWeeks}-${shift.offWeeks})`;
+        const firstName = shift.name.split(' ')[0];
+        nameText.textContent = `${firstName} (${shift.workWeeks}-${shift.offWeeks})`;
 
         turnusItem.appendChild(colorBox);
         turnusItem.appendChild(nameText);


### PR DESCRIPTION
## Summary
- move the 'show my shift' toggle into the colleague section
- style the toggle like the colleague list
- display first names in the shift overview
- sort colleagues alphabetically
- label the toggle with `(meg)`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6850090643688333b9717e79e6a5f26e