### PR TITLE
Ensure user card overlays calendar

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -289,6 +289,7 @@ a:hover {
     width: 100%;
     height: 100%;
     background-color: rgba(0, 0, 0, 0.5);
+    z-index: 2000;
 }
 
 .modal-content {
@@ -297,6 +298,7 @@ a:hover {
     padding: 20px;
     border-radius: 8px;
     max-width: 500px;
+    z-index: 2001;
 }
 .close {
     float: right;


### PR DESCRIPTION
## Summary
- raise modal z-index so calendar doesn't show through

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_e_6850129265288333921d30d0229aa7d3