### PR TITLE
Improve profile preview card

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -385,7 +385,7 @@ a:hover {
 }
 
 .user-card .user-info .name {
-    font-size: 1.1rem;
+    font-size: 1.2rem;
     margin-bottom: 5px;
 }
 .user-card .user-info p {

--- a/js/user_card.js
+++ b/js/user_card.js
@@ -17,7 +17,11 @@ function createCard(user, options = {}) {
     info.className = 'user-info';
     const name = user.firstname ? `${user.firstname} ${user.lastname || ''}` : (user.fullname || '');
     info.innerHTML = `<p class="name"><strong>${name.trim()}</strong></p>`;
-    if (!options.compact) {
+    if (options.compact) {
+        if (user.company) info.innerHTML += `<p><strong>Firma:</strong> ${user.company}</p>`;
+        if (user.location) info.innerHTML += `<p><strong>Arbeidssted:</strong> ${user.location}</p>`;
+        if (user.shift) info.innerHTML += `<p><strong>Turnus:</strong> ${user.shift}</p>`;
+    } else {
         if (user.company) info.innerHTML += `<p>${user.company}</p>`;
         if (user.location) info.innerHTML += `<p>${user.location}</p>`;
         if (user.shift) info.innerHTML += `<p>${user.shift}</p>`;

--- a/js/user_profile.js
+++ b/js/user_profile.js
@@ -196,7 +196,7 @@ function showPreview() {
         user.location = document.getElementById('location').value;
         user.shift = document.getElementById('shift').value;
     }
-    const card = createCard(user, {});
+    const card = createCard(user, { compact: true });
     content.innerHTML = '';
     content.appendChild(card);
     modal.style.display = 'block';


### PR DESCRIPTION
## Summary
- show a compact profile card when previewing user info
- label company, location and shift fields in compact cards
- enlarge name text in card CSS

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685016b693fc8333ae322c42a3bfca12