### PR TITLE
Improve colleague preview and profile page layout

### DIFF
--- a/css/user_profile.css
+++ b/css/user_profile.css
@@ -4,7 +4,7 @@
 /* Sentraler profilboksen */
 .user-profile {
     max-width: 600px;
-    margin: 50px auto;
+    margin: 0 auto;
     padding: 20px;
 }
 

--- a/friends.html
+++ b/friends.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="css/style.css">
     <link rel="stylesheet" href="css/header.css">
     <link rel="stylesheet" href="css/friends.css"><!-- new -->
+    <link rel="stylesheet" href="css/user_profile.css">
     <script defer src="js/session.js"></script>
     <script defer src="js/user_card.js"></script>
     <script defer src="js/friends.js"></script><!-- new -->

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
         <link rel="stylesheet" href="css/style.css">
         <link rel="stylesheet" href="css/header.css">
         <link rel="stylesheet" href="css/calendar.css">
+        <link rel="stylesheet" href="css/user_profile.css">
     <script defer src="js/message.js"></script>
     <script defer src="js/user_card.js"></script>
     <script defer src="js/kalender.js"></script>

--- a/js/friends.js
+++ b/js/friends.js
@@ -187,7 +187,7 @@ function showColleagueInfo(id) {
             if (!data || data.status !== 'success') return;
             const modal = document.getElementById('colleague-modal');
             const content = document.getElementById('colleague-content');
-            const card = createCard(data.user, {});
+            const card = createProfileCard(data.user);
             content.innerHTML = '';
             content.appendChild(card);
             modal.style.display = 'block';

--- a/js/kalender.js
+++ b/js/kalender.js
@@ -376,7 +376,7 @@ function showColleagueCard(id) {
             if (!data || data.status !== 'success') return;
             const modal = document.getElementById('colleague-modal');
             const content = document.getElementById('colleague-content');
-            const card = createCard(data.user, {});
+            const card = createProfileCard(data.user);
             content.innerHTML = '';
             content.appendChild(card);
             modal.style.display = 'block';

--- a/js/user_card.js
+++ b/js/user_card.js
@@ -91,3 +91,37 @@ function createCard(user, options = {}) {
     }
     return card;
 }
+
+function createProfileCard(user) {
+    const card = document.createElement('div');
+    card.className = 'profile-card fade';
+
+    const nameEl = document.createElement('h2');
+    nameEl.className = 'profile-name';
+    const name = user.firstname ? `${user.firstname} ${user.lastname || ''}` : (user.fullname || '');
+    nameEl.textContent = name.trim();
+    card.appendChild(nameEl);
+
+    const contentDiv = document.createElement('div');
+    contentDiv.className = 'profile-content';
+
+    if (user.avatar_url) {
+        const img = document.createElement('img');
+        img.className = 'profile-image';
+        img.src = user.avatar_url;
+        img.alt = 'Profilbilde';
+        contentDiv.appendChild(img);
+    }
+
+    const infoDiv = document.createElement('div');
+    infoDiv.className = 'profile-info';
+    if (!user.info_hide) {
+        if (user.company) infoDiv.innerHTML += `<p><strong>Firma:</strong> ${user.company}</p>`;
+        if (user.location) infoDiv.innerHTML += `<p><strong>Arbeidssted:</strong> ${user.location}</p>`;
+        if (user.shift) infoDiv.innerHTML += `<p><strong>Turnus:</strong> ${user.shift}</p>`;
+    }
+
+    contentDiv.appendChild(infoDiv);
+    card.appendChild(contentDiv);
+    return card;
+}

--- a/user_profile.html
+++ b/user_profile.html
@@ -110,10 +110,10 @@
                 <input type="hidden" id="info-hide" name="info-hide" value="0">
             </section>
 
-            <button type="button" id="toggle-info-btn" class="btn-secondary">Skjul informasjon</button>
+            <button type="submit" class="btn">Oppdater profil</button>
 
             <div class="button-row">
-                <button type="submit" class="btn">Oppdater profil</button>
+                <button type="button" id="toggle-info-btn" class="btn-secondary">Skjul informasjon</button>
                 <button type="button" id="preview-btn" class="btn-secondary">Forhåndsvis</button>
             </div>
 


### PR DESCRIPTION
## Summary
- reuse profile preview card when viewing colleagues
- include profile card styles on calendar and friends pages
- rearrange buttons on the user profile page
- tweak profile form margin for consistent heading placement

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68502ddc7af88333ba0cfec683247594