### PR TITLE
Fix password reset link URL

### DIFF
--- a/backend/forgot_password.php
+++ b/backend/forgot_password.php
@@ -40,7 +40,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
             $stmt->execute();
 
             // Lag tilbakestillingslenken
-            $reset_link = "https://kalenderturnus.no/reset_password.html?token=" . $token;
+            $reset_link = "https://minturnus.no/reset_password.html?token=" . $token;
 
             // Bruk PHPMailer til å sende e-post med tilbakestillingslenken
             $mail = new PHPMailer(true);


### PR DESCRIPTION
## Summary
- point forgot password email link to `minturnus.no` instead of `kalenderturnus.no`

## Testing
- `php -l backend/forgot_password.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68503ed77d0c83338b2b733458ab68f8