### PR TITLE
Auto login and redirect after registration

### DIFF
--- a/backend/register.php
+++ b/backend/register.php
@@ -1,4 +1,5 @@
 <?php
+session_start();
 // Inkluder database.php for å koble til databasen
 require_once 'database.php';
 
@@ -56,7 +57,14 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
         $stmt->bindParam(':password', $hashed_password, PDO::PARAM_STR);
         $stmt->execute();
 
-        // Send suksessmelding når registreringen er vellykket, inkludert brukernavn
+        // Hent ID-en til den nylig opprettede brukeren
+        $newUserId = $db->lastInsertId();
+
+        // Logg inn brukeren ved å lagre info i sesjonen
+        $_SESSION['user_id'] = $newUserId;
+        $_SESSION['user_name'] = $firstname;
+
+        // Send suksessmelding når registreringen er vellykket
         echo json_encode(["success" => true, "message" => "Bruker er opprettet", "firstname" => $firstname]);
         exit; // Stopp all annen output
 

--- a/js/login.js
+++ b/js/login.js
@@ -50,11 +50,15 @@ document.addEventListener('DOMContentLoaded', function () {
                     errorMessages.textContent = result.message;
                     errorMessages.style.display = 'block';
                 } else if (result.success) {
-                    // Lagre brukernavn i localStorage
+                    // Lagre brukernavn i localStorage og send bruker videre
                     console.log('Server response:', result);
                     if (result.success && result.firstname) {
                         localStorage.setItem('userName', result.firstname);
-                        window.location.href = 'index.html'; 
+                        if (action === 'register') {
+                            window.location.href = 'user_profile.html';
+                        } else {
+                            window.location.href = 'index.html';
+                        }
                     } else {
                         showMessage('Innlogging feilet. Sjekk brukernavn og passord.', 'error');
                     }


### PR DESCRIPTION
## Summary
- log user in during registration by setting session data
- after registration, redirect to profile page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68507e5362ac8333975559c1d76f94bb