### PR TITLE
Enable avatar removal and fix cropping UI

### DIFF
--- a/css/user_profile.css
+++ b/css/user_profile.css
@@ -189,3 +189,18 @@
     flex: 1;
     height: 40px;
 }
+
+/* Cropper modal adjustments */
+#cropper-modal .cropper-content {
+    background: #fff;
+    padding: 20px;
+    border-radius: var(--border-radius);
+    text-align: center;
+}
+
+#cropper-image {
+    max-width: 400px;
+    max-height: 60vh;
+    display: block;
+    margin: 0 auto 10px auto;
+}

--- a/user_profile.html
+++ b/user_profile.html
@@ -8,10 +8,12 @@
     <link rel="stylesheet" href="css/style.css">
     <link rel="stylesheet" href="css/header.css">
     <link rel="stylesheet" href="css/user_profile.css">
+    <link rel="stylesheet" href="https://unpkg.com/cropperjs/dist/cropper.min.css">
     <script defer src="js/message.js"></script>
     <script defer src="js/session.js"></script>
     <script defer src="js/user_card.js"></script>
     <script defer src="js/user_profile.js"></script>
+    <script src="https://unpkg.com/cropperjs/dist/cropper.min.js"></script>
 </head>
 <body>
     <header class="header">
@@ -44,6 +46,7 @@
                 </div>
                 <input type="file" id="avatar" name="avatar" accept="image/*">
                 <button type="button" id="avatar-remove" class="btn-secondary">Slett bilde</button>
+                <input type="hidden" id="avatar-remove-flag" name="avatar_remove" value="0">
             </div>
 
             <div class="form-group">
@@ -128,6 +131,14 @@
         <div class="modal-content">
             <span id="modal-close" class="close">&times;</span>
             <div id="preview-content"></div>
+        </div>
+    </div>
+
+    <div id="cropper-modal" class="modal">
+        <div class="modal-content cropper-content">
+            <span id="cropper-close" class="close">&times;</span>
+            <img id="cropper-image" src="" alt="Cropper image">
+            <button type="button" id="cropper-confirm" class="btn">Bruk bilde</button>
         </div>
     </div>
 </body>


### PR DESCRIPTION
## Summary
- attach a hidden flag for avatar deletion and include Cropper.js minified script
- update JS to set the delete flag and send it on profile update
- remove old avatar file in `update_profile.php` when a new one is uploaded or when the user requests deletion

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68507f7a76408333a9c2013e4c6378d2