### PR TITLE
Fix mobile profile interactions

### DIFF
--- a/css/user_profile.css
+++ b/css/user_profile.css
@@ -135,6 +135,7 @@
 @media (max-width: 600px) {
     .form-row {
         flex-direction: column;
+        align-items: flex-start;
     }
 }
 
@@ -187,7 +188,7 @@
 .button-row .btn-secondary {
     margin-bottom: 0;
     flex: 1;
-    height: 40px;
+    min-height: 40px;
 }
 
 /* Cropper modal adjustments */
@@ -204,4 +205,5 @@
     display: block;
     margin: 0 auto 10px auto;
     cursor: crosshair;
+    touch-action: none;
 }

--- a/js/user_profile.js
+++ b/js/user_profile.js
@@ -101,6 +101,11 @@ document.addEventListener('DOMContentLoaded', function () {
         cropperCanvas.addEventListener('mousemove', drag);
         cropperCanvas.addEventListener('mouseup', endDrag);
         cropperCanvas.addEventListener('mouseleave', endDrag);
+        // Touch support for mobile devices
+        cropperCanvas.addEventListener('touchstart', startDrag, {passive: false});
+        cropperCanvas.addEventListener('touchmove', drag, {passive: false});
+        cropperCanvas.addEventListener('touchend', endDrag);
+        cropperCanvas.addEventListener('touchcancel', endDrag);
     }
 
     if (cropperConfirm) {
@@ -191,17 +196,32 @@ function drawCropper() {
     ctx.strokeRect(selection.x, selection.y, selection.size, selection.size);
 }
 
+function getPos(evt) {
+    if (evt.touches && evt.touches.length) {
+        const rect = cropperCanvas.getBoundingClientRect();
+        return {
+            x: evt.touches[0].clientX - rect.left,
+            y: evt.touches[0].clientY - rect.top
+        };
+    }
+    return { x: evt.offsetX, y: evt.offsetY };
+}
+
 function startDrag(evt) {
     if (!ctx) return;
+    evt.preventDefault();
+    const pos = getPos(evt);
     isDragging = true;
-    dragOffsetX = evt.offsetX - selection.x;
-    dragOffsetY = evt.offsetY - selection.y;
+    dragOffsetX = pos.x - selection.x;
+    dragOffsetY = pos.y - selection.y;
 }
 
 function drag(evt) {
     if (!isDragging) return;
-    selection.x = evt.offsetX - dragOffsetX;
-    selection.y = evt.offsetY - dragOffsetY;
+    evt.preventDefault();
+    const pos = getPos(evt);
+    selection.x = pos.x - dragOffsetX;
+    selection.y = pos.y - dragOffsetY;
     selection.x = Math.max(0, Math.min(selection.x, cropperCanvas.width - selection.size));
     selection.y = Math.max(0, Math.min(selection.y, cropperCanvas.height - selection.size));
     drawCropper();


### PR DESCRIPTION
## Summary
- improve mobile cropping by handling touch events
- allow buttons to wrap text and align form rows on small screens
- prevent page scrolling while cropping

## Testing
- `node --check js/user_profile.js`
- *No other tests present*

------
https://chatgpt.com/codex/tasks/task_e_68508fbe4d20833394528b84641997ac