### PR TITLE
Fix calendar grid and header layout

### DIFF
--- a/css/calendar.css
+++ b/css/calendar.css
@@ -45,20 +45,35 @@
 
 .calendar-header {
     display: flex;
-    justify-content: space-between;
-    align-items: center;
-    flex-wrap: wrap;
+    flex-direction: column;
+    gap: 10px;
     padding: 20px 0;
     margin-bottom: 20px;
-    position: relative;
 }
 
-.calendar-header h2 {
-    margin: 0 auto;
-    font-size: 1.8rem;
-    text-align: center;
+.calendar-top {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    flex-wrap: wrap;
+}
+
+.calendar-top h2 {
     flex-grow: 1;
-    color: var(--primary-color);
+    text-align: center;
+}
+
+.calendar-nav {
+    display: flex;
+    justify-content: center;
+    gap: 10px;
+    width: 100%;
+}
+
+.calendar-top-buttons {
+    display: flex;
+    gap: 10px;
 }
 
 .nav-button {
@@ -80,8 +95,6 @@
 
 @media (max-width: 600px) {
     .calendar-header {
-        flex-direction: row;
-        justify-content: space-between;
         padding: 15px 0;
         margin-bottom: 15px;
     }
@@ -92,9 +105,8 @@
         width: auto; /* Unngår full bredde */
     }
 
-    .calendar-header h2 {
+    .calendar-top h2 {
         font-size: 1.2rem; /* Reduserer størrelsen for små skjermer */
-        max-width: 40%; /* Unngår at tittelen tar for mye plass */
     }
 }
 

--- a/index.html
+++ b/index.html
@@ -35,11 +35,17 @@
     <!-- Kalender -->
     <div class="container">
         <div class="calendar-header">
-            <button id="prev-month" class="nav-button">← Forrige</button>
-            <h2 id="month-year">Oktober 2024</h2>
-            <button id="next-month" class="nav-button">Neste →</button>
-            <button id="today-button" class="nav-button">I dag</button>
-            <button id="toggle-year" class="nav-button">Vis år</button>
+            <div class="calendar-top">
+                <h2 id="month-year" class="page-title">Oktober 2024</h2>
+                <div class="calendar-top-buttons">
+                    <button id="today-button" class="nav-button">I dag</button>
+                    <button id="toggle-year" class="nav-button">Vis år</button>
+                </div>
+            </div>
+            <div class="calendar-nav">
+                <button id="prev-month" class="nav-button">← Forrige</button>
+                <button id="next-month" class="nav-button">Neste →</button>
+            </div>
         </div>
         <div class="weekday-row">
             <div class="weekday">MON</div>

--- a/js/kalender.js
+++ b/js/kalender.js
@@ -630,6 +630,14 @@ function renderMonthInto(targetGrid, month, year, hideText = false) {
             targetGrid.appendChild(weekRow);
         }
     }
+
+    // Fyll siste uke med tomme ruter om nødvendig
+    const remainingDays = (7 - ((daysInMonth + firstDay) % 7)) % 7;
+    for (let i = 0; i < remainingDays; i++) {
+        const emptyCell = document.createElement('div');
+        emptyCell.classList.add('day');
+        targetGrid.appendChild(emptyCell);
+    }
 }
 
 function renderCalendar(month, year) {


### PR DESCRIPTION
## Summary
- fill empty cells after the last day of the month so the grid stays uniform
- restructure calendar header layout
- style header to match other page titles

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6850967723dc8333a25943a779763db3