### PR TITLE
Improve mobile year view layout

### DIFF
--- a/css/calendar.css
+++ b/css/calendar.css
@@ -18,6 +18,10 @@
     gap: 10px;
 }
 
+.month-wrapper {
+    margin-bottom: 20px;
+}
+
 .month-wrapper h3 {
     text-align: center;
     margin: 5px 0;
@@ -66,7 +70,7 @@
 
 .calendar-nav {
     display: flex;
-    justify-content: center;
+    justify-content: space-between;
     gap: 10px;
     width: 100%;
 }
@@ -107,6 +111,14 @@
 
     .calendar-top h2 {
         font-size: 1.2rem; /* Reduserer størrelsen for små skjermer */
+    }
+
+    .container.year-view {
+        max-width: 100%;
+    }
+
+    .year-container {
+        grid-template-columns: 1fr;
     }
 }
 


### PR DESCRIPTION
## Summary
- set prev and next navigation buttons to opposite ends
- make year view use single-column months on small screens
- widen year view container and add spacing for each month

## Testing
- `npm test` *(fails: could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68509830414083338603e4c50a768903