### PR TITLE
Improve user search behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ All endpoints require the user to be logged in via PHP sessions.
 These scripts expect the tables `friend_requests` and `friends` in the database
 as described in `js/friends.js`.
 
+The search endpoint requires at least two characters in `query`.
+Results are filtered with a fuzzy match, allowing a Levenshtein
+distance of one or names starting with the query.
+
 ### Creating the friends tables
 
 You can create the required tables manually or import the provided

--- a/api/search_users.php
+++ b/api/search_users.php
@@ -11,7 +11,7 @@ if (!isset($_SESSION['user_id'])) {
 }
 
 $query = isset($_GET['query']) ? trim($_GET['query']) : '';
-if ($query === '') {
+if ($query === '' || mb_strlen($query) < 2) {
     echo json_encode([]);
     exit;
 }
@@ -31,12 +31,18 @@ $sql = "SELECT u.id, u.firstname, u.lastname, u.avatar_url,
         WHERE (u.firstname LIKE ? OR u.lastname LIKE ?) AND u.id != ?
         ORDER BY u.firstname LIMIT 10";
 $stmt = $conn->prepare($sql);
-$stmt->bind_param('iiisssi', $uid, $uid, $uid, $uid, $search, $search, $uid);
+$stmt->bind_param('iiiissi', $uid, $uid, $uid, $uid, $search, $search, $uid);
 $stmt->execute();
 $result = $stmt->get_result();
 $users = [];
+$q = mb_strtolower($query);
 while ($row = $result->fetch_assoc()) {
-    $users[] = $row;
+    $first = mb_strtolower($row['firstname']);
+    $last = mb_strtolower($row['lastname']);
+    if (strpos($first, $q) === 0 || strpos($last, $q) === 0 ||
+        levenshtein($q, $first) <= 1 || levenshtein($q, $last) <= 1) {
+        $users[] = $row;
+    }
 }
 
 echo json_encode($users);

--- a/js/friends.js
+++ b/js/friends.js
@@ -47,7 +47,11 @@ function updateColorOptions() {
 
 function searchUsers() {
     const query = document.getElementById('search-input').value.trim();
-    if (!query) return;
+    const box = document.getElementById('search-results');
+    if (query.length < 2) {
+        box.innerHTML = '<p>Skriv minst to bokstaver.</p>';
+        return;
+    }
 
     fetch(`api/search_users.php?query=${encodeURIComponent(query)}`, {
         credentials: 'include'


### PR DESCRIPTION
## Summary
- require at least two characters before searching for friends in the UI
- fix parameter binding for `search_users.php`
- add fuzzy matching on the server
- document the new search behaviour in the README

## Testing
- `php -l api/search_users.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6850f6a4a34883338511686fc77914b5