### PR TITLE
Improve user search behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,11 @@ All endpoints require the user to be logged in via PHP sessions.
 These scripts expect the tables `friend_requests` and `friends` in the database
 as described in `js/friends.js`.
 
+The search endpoint requires at least two characters in `query`.
+Results are filtered with a fuzzy match. The query may match any part
+of a user's first or last name (split on spaces or hyphen) if the
+Levenshtein distance is one or the part starts with the query.
+
 ### Creating the friends tables
 
 You can create the required tables manually or import the provided

--- a/js/friends.js
+++ b/js/friends.js
@@ -47,7 +47,11 @@ function updateColorOptions() {
 
 function searchUsers() {
     const query = document.getElementById('search-input').value.trim();
-    if (!query) return;
+    const box = document.getElementById('search-results');
+    if (query.length < 2) {
+        box.innerHTML = '<p>Skriv minst to bokstaver.</p>';
+        return;
+    }
 
     fetch(`api/search_users.php?query=${encodeURIComponent(query)}`, {
         credentials: 'include'


### PR DESCRIPTION
## Summary
- require at least two characters before searching for friends in the UI
- fix parameter binding for `search_users.php`
- add fuzzy matching on the server, including support for multi-part names
- document the new search behaviour in the README

## Testing
- `npm test` *(fails: network restricted)*
- `php -l api/search_users.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6850f6a4a34883338511686fc77914b5