### PR TITLE
Add cookie consent banner

### DIFF
--- a/about.html
+++ b/about.html
@@ -7,7 +7,9 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter&family=Roboto&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="css/style.css">
     <link rel="stylesheet" href="css/header.css">
+    <link rel="stylesheet" href="css/cookie-consent.css">
     <script defer src="js/session.js"></script>
+    <script defer src="js/cookie-consent.js"></script>
 </head>
 <body class="about-page">
     <header class="header">
@@ -46,7 +48,13 @@
                 <li>Skjul eller vis profilen din med "Skjul informasjon".</li>
                 <li>Send kollegaforespørsel og svar på forespørsler.</li>
             </ul>
-        </main>
+</main>
+
+    <div id="cookie-banner" class="cookie-banner">
+        <p>Dette nettstedet bruker cookies og localStorage for å gi deg en bedre opplevelse.</p>
+        <button id="accept-cookies">Godta</button>
+        <button id="reject-cookies">Avslå</button>
+    </div>
 
 </body>
 </html>

--- a/change_password.html
+++ b/change_password.html
@@ -7,9 +7,11 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter&family=Roboto&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="css/style.css">
     <link rel="stylesheet" href="css/header.css">
+    <link rel="stylesheet" href="css/cookie-consent.css">
     <script defer src="js/message.js"></script>
     <script defer src="js/session.js"></script>
     <script defer src="js/change_password.js"></script>
+    <script defer src="js/cookie-consent.js"></script>
 </head>
 <body>
     <header class="header">
@@ -45,7 +47,13 @@
             </div>
             <button type="submit" class="btn">Oppdater passord</button>
         </form>
-        <div id="message"></div>
+    <div id="message"></div>
+    </div>
+
+    <div id="cookie-banner" class="cookie-banner">
+        <p>Dette nettstedet bruker cookies og localStorage for å gi deg en bedre opplevelse.</p>
+        <button id="accept-cookies">Godta</button>
+        <button id="reject-cookies">Avslå</button>
     </div>
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -7,8 +7,10 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter&family=Roboto&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="css/style.css">
     <link rel="stylesheet" href="css/header.css">
+    <link rel="stylesheet" href="css/cookie-consent.css">
     <script defer src="js/session.js"></script>
     <script defer src="js/contact.js"></script>
+    <script defer src="js/cookie-consent.js"></script>
 
 </head>
 <body>
@@ -86,5 +88,12 @@
             });
         }
     </script>
+
+    <div id="cookie-banner" class="cookie-banner">
+        <p>Dette nettstedet bruker cookies og localStorage for å gi deg en bedre opplevelse.</p>
+        <button id="accept-cookies">Godta</button>
+        <button id="reject-cookies">Avslå</button>
+    </div>
+
 </body>
 </html>

--- a/css/cookie-consent.css
+++ b/css/cookie-consent.css
@@ -1,0 +1,17 @@
+.cookie-banner {
+    display: none;
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    padding: 15px;
+    background-color: var(--secondary-color);
+    color: var(--light-color);
+    z-index: 1000;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.cookie-banner button {
+    margin-left: 10px;
+}

--- a/forgot_password.html
+++ b/forgot_password.html
@@ -7,7 +7,9 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter&family=Roboto&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="css/style.css">
     <link rel="stylesheet" href="css/header.css">
+    <link rel="stylesheet" href="css/cookie-consent.css">
     <script defer src="js/session.js"></script>
+    <script defer src="js/cookie-consent.js"></script>
 </head>
 <body>
     <header class="header">
@@ -93,5 +95,12 @@
             };
         });
     </script>
+
+    <div id="cookie-banner" class="cookie-banner">
+        <p>Dette nettstedet bruker cookies og localStorage for å gi deg en bedre opplevelse.</p>
+        <button id="accept-cookies">Godta</button>
+        <button id="reject-cookies">Avslå</button>
+    </div>
+
 </body>
 </html>

--- a/friends.html
+++ b/friends.html
@@ -9,9 +9,11 @@
     <link rel="stylesheet" href="css/header.css">
     <link rel="stylesheet" href="css/friends.css"><!-- new -->
     <link rel="stylesheet" href="css/user_profile.css">
+    <link rel="stylesheet" href="css/cookie-consent.css">
     <script defer src="js/session.js"></script>
     <script defer src="js/user_card.js"></script>
     <script defer src="js/friends.js"></script><!-- new -->
+    <script defer src="js/cookie-consent.js"></script>
 </head>
 <body>
 <header class="header">
@@ -60,5 +62,12 @@
         </div>
     </div>
 </div>
+
+    <div id="cookie-banner" class="cookie-banner">
+        <p>Dette nettstedet bruker cookies og localStorage for å gi deg en bedre opplevelse.</p>
+        <button id="accept-cookies">Godta</button>
+        <button id="reject-cookies">Avslå</button>
+    </div>
+
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -8,11 +8,13 @@
         <link rel="stylesheet" href="css/style.css">
         <link rel="stylesheet" href="css/header.css">
         <link rel="stylesheet" href="css/calendar.css">
-        <link rel="stylesheet" href="css/user_profile.css">
+    <link rel="stylesheet" href="css/user_profile.css">
+    <link rel="stylesheet" href="css/cookie-consent.css">
     <script defer src="js/message.js"></script>
     <script defer src="js/user_card.js"></script>
     <script defer src="js/kalender.js"></script>
     <script defer src="js/session.js"></script>
+    <script defer src="js/cookie-consent.js"></script>
 </head>
 <body>
     <header class="header">
@@ -123,6 +125,13 @@
         <div id="colleague-content"></div>
     </div>
 </div>
+
+
+    <div id="cookie-banner" class="cookie-banner">
+        <p>Dette nettstedet bruker cookies og localStorage for å gi deg en bedre opplevelse.</p>
+        <button id="accept-cookies">Godta</button>
+        <button id="reject-cookies">Avslå</button>
+    </div>
 
 
 </body>

--- a/js/cookie-consent.js
+++ b/js/cookie-consent.js
@@ -1,0 +1,24 @@
+if (typeof document !== 'undefined') {
+  document.addEventListener('DOMContentLoaded', () => {
+    const banner = document.getElementById('cookie-banner');
+    if (!banner) return;
+    const consent = localStorage.getItem('cookieConsent');
+    if (!consent) {
+      banner.style.display = 'flex';
+    }
+    const acceptBtn = document.getElementById('accept-cookies');
+    const rejectBtn = document.getElementById('reject-cookies');
+    if (acceptBtn) {
+      acceptBtn.onclick = () => {
+        localStorage.setItem('cookieConsent', 'accepted');
+        banner.style.display = 'none';
+      };
+    }
+    if (rejectBtn) {
+      rejectBtn.onclick = () => {
+        localStorage.setItem('cookieConsent', 'rejected');
+        banner.style.display = 'none';
+      };
+    }
+  });
+}

--- a/login.html
+++ b/login.html
@@ -7,10 +7,12 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter&family=Roboto&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="css/style.css">
     <link rel="stylesheet" href="css/header.css">
+    <link rel="stylesheet" href="css/cookie-consent.css">
     <script defer src="js/message.js"></script>
     <script defer src="js/session.js"></script>
     <script defer src="js/login.js"></script>
     <script defer src="js/forgot_password.js"></script>
+    <script defer src="js/cookie-consent.js"></script>
 
 </head>
 <body>
@@ -45,7 +47,13 @@
             <div id="message"></div>
             <button type="button" class="btn-secondary" id="reset-password-btn">Glemt passord?</button>
             <p>Har du ikke bruker? <a href="register.html">Registrer ny bruker</a></p>
-        </form>
+</form>
+    </div>
+
+    <div id="cookie-banner" class="cookie-banner">
+        <p>Dette nettstedet bruker cookies og localStorage for å gi deg en bedre opplevelse.</p>
+        <button id="accept-cookies">Godta</button>
+        <button id="reject-cookies">Avslå</button>
     </div>
 </body>
 </html>

--- a/register.html
+++ b/register.html
@@ -7,8 +7,10 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter&family=Roboto&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="css/style.css">
     <link rel="stylesheet" href="css/header.css">
+    <link rel="stylesheet" href="css/cookie-consent.css">
     <script defer src="js/session.js"></script>
     <script defer src="js/login.js"></script>
+    <script defer src="js/cookie-consent.js"></script>
 </head>
 <body>
     <header class="header">
@@ -77,5 +79,11 @@
             }
         });
     </script>
+
+    <div id="cookie-banner" class="cookie-banner">
+        <p>Dette nettstedet bruker cookies og localStorage for å gi deg en bedre opplevelse.</p>
+        <button id="accept-cookies">Godta</button>
+        <button id="reject-cookies">Avslå</button>
+    </div>
 </body>
 </html>

--- a/reset_password.html
+++ b/reset_password.html
@@ -7,7 +7,9 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter&family=Roboto&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="css/style.css">
     <link rel="stylesheet" href="css/header.css">
+    <link rel="stylesheet" href="css/cookie-consent.css">
     <script defer src="js/session.js"></script>
+    <script defer src="js/cookie-consent.js"></script>
 </head>
 <body>
     <header class="header">
@@ -103,5 +105,12 @@
             });
         });
     </script>
+
+    <div id="cookie-banner" class="cookie-banner">
+        <p>Dette nettstedet bruker cookies and localStorage for å gi deg en bedre opplevelse.</p>
+        <button id="accept-cookies">Godta</button>
+        <button id="reject-cookies">Avslå</button>
+    </div>
+
 </body>
 </html>

--- a/user_profile.html
+++ b/user_profile.html
@@ -8,10 +8,12 @@
     <link rel="stylesheet" href="css/style.css">
     <link rel="stylesheet" href="css/header.css">
     <link rel="stylesheet" href="css/user_profile.css">
+    <link rel="stylesheet" href="css/cookie-consent.css">
     <script defer src="js/message.js"></script>
     <script defer src="js/session.js"></script>
     <script defer src="js/user_card.js"></script>
     <script defer src="js/user_profile.js"></script>
+    <script defer src="js/cookie-consent.js"></script>
 </head>
 <body>
     <header class="header">
@@ -138,6 +140,12 @@
             <canvas id="cropper-canvas"></canvas>
             <button type="button" id="cropper-confirm" class="btn">Bruk bilde</button>
         </div>
+</div>
+
+    <div id="cookie-banner" class="cookie-banner">
+        <p>Dette nettstedet bruker cookies og localStorage for å gi deg en bedre opplevelse.</p>
+        <button id="accept-cookies">Godta</button>
+        <button id="reject-cookies">Avslå</button>
     </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- implement `cookie-consent.js` and banner styles
- load cookie banner on all pages
- show banner asking for consent if no decision stored

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68510ce9b0648333a8cfc5b53b61b047