### PR TITLE
Update cookie consent banner

### DIFF
--- a/about.html
+++ b/about.html
@@ -51,9 +51,11 @@
 </main>
 
     <div id="cookie-banner" class="cookie-banner">
-        <p>Dette nettstedet bruker cookies og localStorage for å gi deg en bedre opplevelse.</p>
-        <button id="accept-cookies">Godta</button>
-        <button id="reject-cookies">Avslå</button>
+        <p>Dette nettstedet bruker informasjonskapsler til å lagre dine innstillinger i nettleseren og forbedre opplevelsen i henhold til gjeldende personvernlovgivning.</p>
+        <div class="button-group">
+            <button id="accept-cookies" class="btn">Godta</button>
+            <button id="reject-cookies" class="btn-secondary">Avslå</button>
+        </div>
     </div>
 
 </body>

--- a/change_password.html
+++ b/change_password.html
@@ -51,9 +51,11 @@
     </div>
 
     <div id="cookie-banner" class="cookie-banner">
-        <p>Dette nettstedet bruker cookies og localStorage for å gi deg en bedre opplevelse.</p>
-        <button id="accept-cookies">Godta</button>
-        <button id="reject-cookies">Avslå</button>
+        <p>Dette nettstedet bruker informasjonskapsler til å lagre dine innstillinger i nettleseren og forbedre opplevelsen i henhold til gjeldende personvernlovgivning.</p>
+        <div class="button-group">
+            <button id="accept-cookies" class="btn">Godta</button>
+            <button id="reject-cookies" class="btn-secondary">Avslå</button>
+        </div>
     </div>
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -90,9 +90,11 @@
     </script>
 
     <div id="cookie-banner" class="cookie-banner">
-        <p>Dette nettstedet bruker cookies og localStorage for å gi deg en bedre opplevelse.</p>
-        <button id="accept-cookies">Godta</button>
-        <button id="reject-cookies">Avslå</button>
+        <p>Dette nettstedet bruker informasjonskapsler til å lagre dine innstillinger i nettleseren og forbedre opplevelsen i henhold til gjeldende personvernlovgivning.</p>
+        <div class="button-group">
+            <button id="accept-cookies" class="btn">Godta</button>
+            <button id="reject-cookies" class="btn-secondary">Avslå</button>
+        </div>
     </div>
 
 </body>

--- a/css/cookie-consent.css
+++ b/css/cookie-consent.css
@@ -6,12 +6,20 @@
     right: 0;
     padding: 15px;
     background-color: var(--secondary-color);
-    color: var(--light-color);
+    color: var(--text-color);
     z-index: 1000;
     justify-content: space-between;
     align-items: center;
 }
 
-.cookie-banner button {
-    margin-left: 10px;
+.cookie-banner .button-group {
+    display: flex;
+    gap: 10px;
+}
+
+.cookie-banner .btn,
+.cookie-banner .btn-secondary {
+    width: auto;
+    padding: 8px 16px;
+    margin-bottom: 0;
 }

--- a/forgot_password.html
+++ b/forgot_password.html
@@ -97,9 +97,11 @@
     </script>
 
     <div id="cookie-banner" class="cookie-banner">
-        <p>Dette nettstedet bruker cookies og localStorage for å gi deg en bedre opplevelse.</p>
-        <button id="accept-cookies">Godta</button>
-        <button id="reject-cookies">Avslå</button>
+        <p>Dette nettstedet bruker informasjonskapsler til å lagre dine innstillinger i nettleseren og forbedre opplevelsen i henhold til gjeldende personvernlovgivning.</p>
+        <div class="button-group">
+            <button id="accept-cookies" class="btn">Godta</button>
+            <button id="reject-cookies" class="btn-secondary">Avslå</button>
+        </div>
     </div>
 
 </body>

--- a/friends.html
+++ b/friends.html
@@ -64,9 +64,11 @@
 </div>
 
     <div id="cookie-banner" class="cookie-banner">
-        <p>Dette nettstedet bruker cookies og localStorage for å gi deg en bedre opplevelse.</p>
-        <button id="accept-cookies">Godta</button>
-        <button id="reject-cookies">Avslå</button>
+        <p>Dette nettstedet bruker informasjonskapsler til å lagre dine innstillinger i nettleseren og forbedre opplevelsen i henhold til gjeldende personvernlovgivning.</p>
+        <div class="button-group">
+            <button id="accept-cookies" class="btn">Godta</button>
+            <button id="reject-cookies" class="btn-secondary">Avslå</button>
+        </div>
     </div>
 
 </body>

--- a/index.html
+++ b/index.html
@@ -128,9 +128,11 @@
 
 
     <div id="cookie-banner" class="cookie-banner">
-        <p>Dette nettstedet bruker cookies og localStorage for å gi deg en bedre opplevelse.</p>
-        <button id="accept-cookies">Godta</button>
-        <button id="reject-cookies">Avslå</button>
+        <p>Dette nettstedet bruker informasjonskapsler til å lagre dine innstillinger i nettleseren og forbedre opplevelsen i henhold til gjeldende personvernlovgivning.</p>
+        <div class="button-group">
+            <button id="accept-cookies" class="btn">Godta</button>
+            <button id="reject-cookies" class="btn-secondary">Avslå</button>
+        </div>
     </div>
 
 

--- a/login.html
+++ b/login.html
@@ -51,9 +51,11 @@
     </div>
 
     <div id="cookie-banner" class="cookie-banner">
-        <p>Dette nettstedet bruker cookies og localStorage for å gi deg en bedre opplevelse.</p>
-        <button id="accept-cookies">Godta</button>
-        <button id="reject-cookies">Avslå</button>
+        <p>Dette nettstedet bruker informasjonskapsler til å lagre dine innstillinger i nettleseren og forbedre opplevelsen i henhold til gjeldende personvernlovgivning.</p>
+        <div class="button-group">
+            <button id="accept-cookies" class="btn">Godta</button>
+            <button id="reject-cookies" class="btn-secondary">Avslå</button>
+        </div>
     </div>
 </body>
 </html>

--- a/register.html
+++ b/register.html
@@ -81,9 +81,11 @@
     </script>
 
     <div id="cookie-banner" class="cookie-banner">
-        <p>Dette nettstedet bruker cookies og localStorage for å gi deg en bedre opplevelse.</p>
-        <button id="accept-cookies">Godta</button>
-        <button id="reject-cookies">Avslå</button>
+        <p>Dette nettstedet bruker informasjonskapsler til å lagre dine innstillinger i nettleseren og forbedre opplevelsen i henhold til gjeldende personvernlovgivning.</p>
+        <div class="button-group">
+            <button id="accept-cookies" class="btn">Godta</button>
+            <button id="reject-cookies" class="btn-secondary">Avslå</button>
+        </div>
     </div>
 </body>
 </html>

--- a/reset_password.html
+++ b/reset_password.html
@@ -107,9 +107,11 @@
     </script>
 
     <div id="cookie-banner" class="cookie-banner">
-        <p>Dette nettstedet bruker cookies and localStorage for å gi deg en bedre opplevelse.</p>
-        <button id="accept-cookies">Godta</button>
-        <button id="reject-cookies">Avslå</button>
+        <p>Dette nettstedet bruker informasjonskapsler til å lagre dine innstillinger i nettleseren og forbedre opplevelsen i henhold til gjeldende personvernlovgivning.</p>
+        <div class="button-group">
+            <button id="accept-cookies" class="btn">Godta</button>
+            <button id="reject-cookies" class="btn-secondary">Avslå</button>
+        </div>
     </div>
 
 </body>

--- a/user_profile.html
+++ b/user_profile.html
@@ -143,9 +143,11 @@
 </div>
 
     <div id="cookie-banner" class="cookie-banner">
-        <p>Dette nettstedet bruker cookies og localStorage for å gi deg en bedre opplevelse.</p>
-        <button id="accept-cookies">Godta</button>
-        <button id="reject-cookies">Avslå</button>
+        <p>Dette nettstedet bruker informasjonskapsler til å lagre dine innstillinger i nettleseren og forbedre opplevelsen i henhold til gjeldende personvernlovgivning.</p>
+        <div class="button-group">
+            <button id="accept-cookies" class="btn">Godta</button>
+            <button id="reject-cookies" class="btn-secondary">Avslå</button>
+        </div>
     </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- restyle cookie consent banner so the buttons use the site's main button classes
- clarify consent text and remove reference to localStorage

## Testing
- `npm test` *(fails: package.json missing)*
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68510fda88608333badd4b18cd6b57e2