### PR TITLE
Hide colleagues when logged out

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@
         <div id="year-container" class="year-container"></div>
         <div id="turnus-oversikt" class="turnus-oversikt"></div>
 
-        <div class="colleague-section">
+        <div id="colleague-section" class="colleague-section" style="display:none;">
             <h3>Kollegaer i kalenderen</h3>
             <p class="colleague-info">Her ser du kollegaer du allerede har lagt til. For å legge til nye kollegaer, gå til kollega-siden eller <a href="friends.html">trykk her</a>.</p>
             <label for="colleague-search">Filtrer kollegaene nedenfor</label>

--- a/js/session.js
+++ b/js/session.js
@@ -25,6 +25,7 @@ document.addEventListener('DOMContentLoaded', async function () {
     const profileItem = document.getElementById('profile-item');
     const loginLink = document.getElementById('login-link');
     const requestAlert = document.getElementById('request-alert');
+    const colleagueSection = document.getElementById('colleague-section');
 
     // Håndter innloggingsstatus
     if (userName) {
@@ -37,6 +38,7 @@ document.addEventListener('DOMContentLoaded', async function () {
         if (friendsItem) friendsItem.style.display = 'list-item';
         if (profileItem) profileItem.style.display = 'list-item';
         if (requestAlert) requestAlert.style.display = 'inline';
+        if (colleagueSection) colleagueSection.style.display = 'block';
 
         // Skjul "Logg inn"-lenken når brukeren er logget inn
         if (loginLink) {
@@ -51,6 +53,7 @@ document.addEventListener('DOMContentLoaded', async function () {
         // Sørg for at "Logg inn"-lenken vises
         if (loginLink) loginLink.style.display = 'list-item';
         if (requestAlert) requestAlert.style.display = 'none';
+        if (colleagueSection) colleagueSection.style.display = 'none';
     }
 
     // Global event listener for utlogging


### PR DESCRIPTION
## Summary
- keep colleague section hidden until user has logged in
- toggle the section visibility based on session status

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68527d123d90833398a3bb599cc6c50e