### PR TITLE
Add remember me persistent login

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,4 +109,13 @@ CREATE TABLE `friends` (
   `user2` INT NOT NULL,
   PRIMARY KEY (`user1`, `user2`)
 );
+
+-- Persistent login tokens used by the "remember me" feature
+CREATE TABLE `remember_tokens` (
+  `id` INT AUTO_INCREMENT PRIMARY KEY,
+  `user_id` INT NOT NULL,
+  `token_hash` CHAR(64) NOT NULL,
+  `expires_at` DATETIME NOT NULL,
+  KEY `user_id` (`user_id`)
+);
 ```

--- a/backend/login.php
+++ b/backend/login.php
@@ -10,6 +10,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     // Hent input fra skjemaet
     $email = trim($_POST['email']);
     $password = trim($_POST['password']);
+    $remember = isset($_POST['rememberMe']);
 
     try {
         // Koble til databasen
@@ -28,6 +29,18 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
                 // Opprett sesjon for brukeren
                 $_SESSION['user_id'] = $user['id'];
                 $_SESSION['user_name'] = $user['firstname'];
+
+                if ($remember) {
+                    // Generer token og lagre hash i databasen
+                    $token = bin2hex(random_bytes(32));
+                    $tokenHash = hash('sha256', $token);
+                    $expires = date('Y-m-d H:i:s', time() + 60 * 60 * 24 * 30);
+
+                    $insert = $db->prepare("INSERT INTO remember_tokens (user_id, token_hash, expires_at) VALUES (:uid, :hash, :exp)");
+                    $insert->execute([':uid' => $user['id'], ':hash' => $tokenHash, ':exp' => $expires]);
+
+                    setcookie('remember_token', $token, time() + 60 * 60 * 24 * 30, '/', '', isset($_SERVER['HTTPS']), true);
+                }
 
                 // Etter at brukeren har logget inn, returner brukernavn
                 echo json_encode(["success" => true, "message" => "Innlogging vellykket", "firstname" => $user['firstname']]);

--- a/backend/logout.php
+++ b/backend/logout.php
@@ -1,5 +1,19 @@
 <?php
 session_start();
+require_once 'database.php';
+
+if (isset($_COOKIE['remember_token'])) {
+    $tokenHash = hash('sha256', $_COOKIE['remember_token']);
+    try {
+        $db = new PDO($dsn, $username, $db_password, $options);
+        $stmt = $db->prepare('DELETE FROM remember_tokens WHERE token_hash = :hash');
+        $stmt->execute([':hash' => $tokenHash]);
+    } catch (PDOException $e) {
+        // ignore errors when logging out
+    }
+    setcookie('remember_token', '', time() - 3600, '/', '', isset($_SERVER['HTTPS']), true);
+}
+
 session_destroy();
 header('Location: index.html');
 exit;

--- a/backend/session_status.php
+++ b/backend/session_status.php
@@ -1,10 +1,40 @@
 <?php
 session_start();
+require_once 'database.php';
+
+if (!isset($_SESSION['user_id']) && isset($_COOKIE['remember_token'])) {
+    $tokenHash = hash('sha256', $_COOKIE['remember_token']);
+
+    try {
+        $db = new PDO($dsn, $username, $db_password, $options);
+        $stmt = $db->prepare('SELECT user_id FROM remember_tokens WHERE token_hash = :hash AND expires_at > NOW()');
+        $stmt->execute([':hash' => $tokenHash]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        if ($row) {
+            $userStmt = $db->prepare('SELECT firstname FROM users WHERE id = :id');
+            $userStmt->execute([':id' => $row['user_id']]);
+            $user = $userStmt->fetch(PDO::FETCH_ASSOC);
+            if ($user) {
+                $_SESSION['user_id'] = $row['user_id'];
+                $_SESSION['user_name'] = $user['firstname'];
+
+                $newExpiry = date('Y-m-d H:i:s', time() + 60 * 60 * 24 * 30);
+                $update = $db->prepare('UPDATE remember_tokens SET expires_at = :exp WHERE token_hash = :hash');
+                $update->execute([':exp' => $newExpiry, ':hash' => $tokenHash]);
+
+                setcookie('remember_token', $_COOKIE['remember_token'], time() + 60 * 60 * 24 * 30, '/', '', isset($_SERVER['HTTPS']), true);
+            }
+        } else {
+            setcookie('remember_token', '', time() - 3600, '/', '', isset($_SERVER['HTTPS']), true);
+        }
+    } catch (PDOException $e) {
+        // ignore database errors here
+    }
+}
+
 if (isset($_SESSION['user_id'])) {
-    // Hvis brukeren er innlogget, returner brukernavn og status
     echo json_encode(["loggedIn" => true, "userName" => $_SESSION['user_name']]);
 } else {
-    // Hvis brukeren ikke er innlogget, returner status som false
     echo json_encode(["loggedIn" => false]);
 }
 ?>

--- a/login.html
+++ b/login.html
@@ -43,6 +43,10 @@
             <div class="form-group">
                 <input type="password" id="password" name="password" placeholder="Passord" required>
             </div>
+            <div class="form-group">
+                <input type="checkbox" id="rememberMe" name="rememberMe">
+                <label for="rememberMe">Husk meg</label>
+            </div>
             <button type="submit" class="btn">Logg inn</button>
             <div id="message"></div>
             <button type="button" class="btn-secondary" id="reset-password-btn">Glemt passord?</button>

--- a/schema.sql
+++ b/schema.sql
@@ -17,3 +17,12 @@ CREATE TABLE `friends` (
   `user2` INT NOT NULL,
   PRIMARY KEY (`user1`, `user2`)
 );
+
+-- Table storing persistent login tokens
+CREATE TABLE `remember_tokens` (
+  `id` INT AUTO_INCREMENT PRIMARY KEY,
+  `user_id` INT NOT NULL,
+  `token_hash` CHAR(64) NOT NULL,
+  `expires_at` DATETIME NOT NULL,
+  KEY `user_id` (`user_id`)
+);


### PR DESCRIPTION
## Summary
- add a checkbox to login.html for remembering login
- create remember_tokens table in SQL schema
- store persistent token when logging in
- automatically restore session via token
- clear token on logout

## Testing
- `php -l backend/login.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685328ad0b308333aad1ed4171187f73