### PR TITLE
Fix week-based shift cycle calculation

### DIFF
--- a/js/kalender.js
+++ b/js/kalender.js
@@ -735,7 +735,7 @@ function renderMonthInto(targetGrid, month, year, hideText = false) {
             const daysSinceStart = Math.floor((date - shift.startDate) / (1000 * 60 * 60 * 24));
             const extraDay = (shift.type === 'dagbasert' || shift.weekdays) ? 0 : 1;
             const workDays = (shift.workWeeks * 7) + extraDay;
-            const cycleLength = (shift.workWeeks * 7) + (shift.offWeeks * 7) + extraDay;
+            const cycleLength = (shift.workWeeks * 7) + (shift.offWeeks * 7);
 
             let cyclePosition = ((daysSinceStart % cycleLength) + cycleLength) % cycleLength;
             if (cyclePosition < workDays) {


### PR DESCRIPTION
## Summary
- fix start date calculation for week-based shifts so cycles don't drift

## Testing
- `node -e "function calc(date,startDate,workWeeks,offWeeks){const daysSinceStart=Math.floor((date-startDate)/86400000);const extraDay=1;const workDays=(workWeeks*7)+extraDay;const cycleLength=(workWeeks*7)+(offWeeks*7);let pos=((daysSinceStart%cycleLength)+cycleLength)%cycleLength;return pos<workDays;} let start=new Date('2024-06-19');for(let i=0;i<60;i++){let d=new Date(start);d.setDate(start.getDate()+i); if(i>=13 && i<=44){console.log(i,d.toISOString().slice(0,10),calc(d,start,2,4));}}"

------
https://chatgpt.com/codex/tasks/task_e_6853a1937c548333ad82d1ddcaf34007