### PR TITLE
Persist close colleagues and style button

### DIFF
--- a/css/calendar.css
+++ b/css/calendar.css
@@ -453,14 +453,25 @@ option {
     color: #555;
 }
 
+
 .colleague-buttons {
     display: flex;
+    flex-wrap: wrap;
     gap: 10px;
-    margin-bottom: 10px;
+    margin-bottom: 15px;
 }
 
 .colleague-buttons .action-btn {
     margin-top: 0;
+}
+
+#colleagues-close {
+    background-color: var(--accent-color);
+    color: var(--primary-color);
+}
+
+#colleagues-close:hover {
+    background-color: #e19600;
 }
 
 .colleague-item {

--- a/js/kalender.js
+++ b/js/kalender.js
@@ -422,6 +422,18 @@ function loadColleaguesList() {
                 }
             });
 
+            // Sørg for at kollegaer markert som "nære" alltid er synlige
+            selectedColleagues.forEach(sc => {
+                if (closeColleagues[sc.id]) sc.visible = true;
+            });
+            colleagues.forEach(c => {
+                if (!c.shift || !c.shift_date) return;
+                if (closeColleagues[c.id] && !selectedColleagues.some(sc => sc.id === c.id)) {
+                    const pref = colleagueColorPref[c.id];
+                    selectedColleagues.push({ id: c.id, color: pref || getNextAvailableColor(), visible: true });
+                }
+            });
+
             if (initialColleagueMode) {
                 setColleagueMode(initialColleagueMode);
                 initialColleagueMode = null;


### PR DESCRIPTION
## Summary
- always show colleagues marked as close when loading calendar
- polish layout and color of the "Nære kollegaer" button

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6853a7fbc1788333874d2c4b44cedd7b