### PR TITLE
Fix near colleague toggle not opening card

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -504,6 +504,17 @@ a:hover {
     gap: 4px;
 }
 
+/* Row for color selector and "Nær kollega" checkbox */
+.settings-row {
+    margin-top: 10px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+.settings-row select {
+    flex: 1;
+}
+
 .fade {
     animation: fade 0.3s ease-out;
 }

--- a/js/user_card.js
+++ b/js/user_card.js
@@ -99,6 +99,9 @@ function createCard(user, options = {}) {
     }
 
     if (options.remove) {
+        const settings = document.createElement('div');
+        settings.className = 'settings-row';
+
         const sel = document.createElement('select');
         const autoOpt = document.createElement('option');
         autoOpt.value = '';
@@ -119,7 +122,7 @@ function createCard(user, options = {}) {
             localStorage.setItem('colleagueColorPref', JSON.stringify(colorPrefs));
             updateColorOptions();
         };
-        content.appendChild(sel);
+        settings.appendChild(sel);
 
         const lbl = document.createElement('label');
         lbl.className = 'close-label';
@@ -127,13 +130,15 @@ function createCard(user, options = {}) {
         cb.type = 'checkbox';
         cb.checked = closePrefs[user.id] || false;
         cb.addEventListener('click', e => e.stopPropagation());
+        lbl.addEventListener('click', e => e.stopPropagation());
         cb.onchange = e => {
             if (e.target.checked) closePrefs[user.id] = true; else delete closePrefs[user.id];
             localStorage.setItem('closeColleagues', JSON.stringify(closePrefs));
         };
         lbl.appendChild(cb);
         lbl.appendChild(document.createTextNode(' Nær kollega'));
-        content.appendChild(lbl);
+        settings.appendChild(lbl);
+        content.appendChild(settings);
 
         const btn = document.createElement('button');
         btn.className = 'action-btn';


### PR DESCRIPTION
## Summary
- add a settings row style for color + checkbox
- stop click propagation on the near colleague label and group controls horizontally

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685431d414c483338c4e3a3861a8fde9