### PR TITLE
Oppdater arbeidssted til lokasjon i brukerprofil

### DIFF
--- a/css/user_profile.css
+++ b/css/user_profile.css
@@ -49,6 +49,37 @@
     color: #666;
 }
 
+/* Tooltip info icon */
+.info-icon {
+    cursor: pointer;
+    font-size: 0.9rem;
+    margin-left: 4px;
+    position: relative;
+    user-select: none;
+}
+
+.info-icon::after {
+    content: attr(data-info);
+    display: none;
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    background: rgba(0, 0, 0, 0.75);
+    color: #fff;
+    padding: 6px 8px;
+    border-radius: 4px;
+    font-size: 0.8rem;
+    white-space: normal;
+    width: 240px;
+    z-index: 10;
+}
+
+.info-icon:hover::after,
+.info-icon:focus::after {
+    display: block;
+}
+
 /* Kort for forhåndsvisning av profil */
 .profile-card {
     width: 100%;

--- a/js/user_card.js
+++ b/js/user_card.js
@@ -58,7 +58,7 @@ function createCard(user, options = {}) {
     if (!options.mini) {
         if (options.compact) {
             if (user.company) info.innerHTML += `<p><strong>Firma:</strong> ${user.company}</p>`;
-            if (user.location) info.innerHTML += `<p><strong>Arbeidssted:</strong> ${user.location}</p>`;
+            if (user.location) info.innerHTML += `<p><strong>Lokasjon:</strong> ${user.location}</p>`;
             if (user.shift) info.innerHTML += `<p><strong>Turnus:</strong> ${user.shift}</p>`;
         } else {
             if (user.company) info.innerHTML += `<p>${user.company}</p>`;
@@ -177,7 +177,7 @@ function createProfileCard(user) {
     infoDiv.className = 'profile-info';
     if (!user.info_hide) {
         if (user.company) infoDiv.innerHTML += `<p><strong>Firma:</strong> ${user.company}</p>`;
-        if (user.location) infoDiv.innerHTML += `<p><strong>Arbeidssted:</strong> ${user.location}</p>`;
+        if (user.location) infoDiv.innerHTML += `<p><strong>Lokasjon:</strong> ${user.location}</p>`;
         if (user.shift) infoDiv.innerHTML += `<p><strong>Turnus:</strong> ${user.shift}</p>`;
     }
 

--- a/js/user_profile.js
+++ b/js/user_profile.js
@@ -410,7 +410,7 @@ function showPreview() {
 
     if (showInfo) {
         if (company) infoDiv.innerHTML += `<p><strong>Firma:</strong> ${company}</p>`;
-        if (location) infoDiv.innerHTML += `<p><strong>Arbeidssted:</strong> ${location}</p>`;
+        if (location) infoDiv.innerHTML += `<p><strong>Lokasjon:</strong> ${location}</p>`;
         if (shift) infoDiv.innerHTML += `<p><strong>Turnus:</strong> ${shift}</p>`;
     }
 

--- a/user_profile.html
+++ b/user_profile.html
@@ -74,7 +74,7 @@
                 </div>
 
                 <div class="form-group">
-                    <label for="location">Arbeidssted</label>
+                    <label for="location">Lokasjon <span class="info-icon" tabindex="0" data-info="Forklaring: Med lokasjon menes typisk plattform, rigg, båt eller lignende. Eksempler: Multi Explorer, Snorre A, Scarabeo 8 eller lignende.">i</span></label>
                     <input type="text" id="location" name="location">
                 </div>
 


### PR DESCRIPTION
## Summary
- oppdater etiketten "Arbeidssted" til "Lokasjon" med info-ikon
- vis forklaringstekst kun i et tooltip ved hover eller trykk

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6854462ca7508333877b42283aec8d04