### PR TITLE
Add logo and favicon support

### DIFF
--- a/about.html
+++ b/about.html
@@ -5,6 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Om MinTurnus</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter&family=Roboto&display=swap" rel="stylesheet">
+<link rel='icon' href='images/favicon.ico' sizes='any'>
+<link rel='icon' type='image/png' href='images/favicon.png'>
+<link rel='apple-touch-icon' href='images/icon-512.png'>
     <link rel="stylesheet" href="css/style.css">
     <link rel="stylesheet" href="css/header.css">
     <link rel="stylesheet" href="css/cookie-consent.css">
@@ -13,7 +16,7 @@
 </head>
 <body class="about-page">
     <header class="header">
-        <h1><a href="index.html">Min<span class="accent-text">Turnus</span></a></h1>
+        <h1><a href="index.html"><img src="images/minturnus_logo.png" alt="MinTurnus-logo" class="site-logo"></a></h1>
         <div class="user-container">
             <div id="user-info"></div>
         </div>

--- a/change_password.html
+++ b/change_password.html
@@ -5,6 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Endre passord - MinTurnus</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter&family=Roboto&display=swap" rel="stylesheet">
+<link rel='icon' href='images/favicon.ico' sizes='any'>
+<link rel='icon' type='image/png' href='images/favicon.png'>
+<link rel='apple-touch-icon' href='images/icon-512.png'>
     <link rel="stylesheet" href="css/style.css">
     <link rel="stylesheet" href="css/header.css">
     <link rel="stylesheet" href="css/cookie-consent.css">
@@ -15,7 +18,7 @@
 </head>
 <body>
     <header class="header">
-        <h1><a href="index.html">Min<span class="accent-text">Turnus</span></a></h1>
+        <h1><a href="index.html"><img src="images/minturnus_logo.png" alt="MinTurnus-logo" class="site-logo"></a></h1>
         <div class="user-container">
             <div id="user-info"></div>
         </div>

--- a/contact.html
+++ b/contact.html
@@ -5,6 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Kontakt - MinTurnus</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter&family=Roboto&display=swap" rel="stylesheet">
+<link rel='icon' href='images/favicon.ico' sizes='any'>
+<link rel='icon' type='image/png' href='images/favicon.png'>
+<link rel='apple-touch-icon' href='images/icon-512.png'>
     <link rel="stylesheet" href="css/style.css">
     <link rel="stylesheet" href="css/header.css">
     <link rel="stylesheet" href="css/cookie-consent.css">
@@ -15,7 +18,7 @@
 </head>
 <body>
     <header class="header">
-        <h1><a href="index.html">Min<span class="accent-text">Turnus</span></a></h1>
+        <h1><a href="index.html"><img src="images/minturnus_logo.png" alt="MinTurnus-logo" class="site-logo"></a></h1>
         <div class="user-container">
             <div id="user-info"></div>
         </div>

--- a/css/header.css
+++ b/css/header.css
@@ -142,3 +142,7 @@
         border: none;
     }
 }
+
+.site-logo {
+    height: 40px;
+}

--- a/forgot_password.html
+++ b/forgot_password.html
@@ -5,6 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Glemt Passord - MinTurnus</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter&family=Roboto&display=swap" rel="stylesheet">
+<link rel='icon' href='images/favicon.ico' sizes='any'>
+<link rel='icon' type='image/png' href='images/favicon.png'>
+<link rel='apple-touch-icon' href='images/icon-512.png'>
     <link rel="stylesheet" href="css/style.css">
     <link rel="stylesheet" href="css/header.css">
     <link rel="stylesheet" href="css/cookie-consent.css">
@@ -13,7 +16,7 @@
 </head>
 <body>
     <header class="header">
-        <h1><a href="index.html">Min<span class="accent-text">Turnus</span></a></h1>
+        <h1><a href="index.html"><img src="images/minturnus_logo.png" alt="MinTurnus-logo" class="site-logo"></a></h1>
         <div class="user-container">
             <div id="user-info"></div>
         </div>

--- a/friends.html
+++ b/friends.html
@@ -5,6 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Kollegaer - MinTurnus</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter&family=Roboto&display=swap" rel="stylesheet">
+<link rel='icon' href='images/favicon.ico' sizes='any'>
+<link rel='icon' type='image/png' href='images/favicon.png'>
+<link rel='apple-touch-icon' href='images/icon-512.png'>
     <link rel="stylesheet" href="css/style.css">
     <link rel="stylesheet" href="css/header.css">
     <link rel="stylesheet" href="css/friends.css"><!-- new -->
@@ -18,7 +21,7 @@
 </head>
 <body>
 <header class="header">
-    <h1><a href="index.html">Min<span class="accent-text">Turnus</span></a></h1>
+    <h1><a href="index.html"><img src="images/minturnus_logo.png" alt="MinTurnus-logo" class="site-logo"></a></h1>
     <div class="user-container">
         <div id="user-info"></div>
     </div>

--- a/index.html
+++ b/index.html
@@ -5,6 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Kalender - MinTurnus</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter&family=Roboto&display=swap" rel="stylesheet">
+<link rel='icon' href='images/favicon.ico' sizes='any'>
+<link rel='icon' type='image/png' href='images/favicon.png'>
+<link rel='apple-touch-icon' href='images/icon-512.png'>
         <link rel="stylesheet" href="css/style.css">
         <link rel="stylesheet" href="css/header.css">
         <link rel="stylesheet" href="css/calendar.css">
@@ -18,7 +21,7 @@
 </head>
 <body>
     <header class="header">
-        <h1><a href="index.html">Min<span class="accent-text">Turnus</span></a></h1>
+        <h1><a href="index.html"><img src="images/minturnus_logo.png" alt="MinTurnus-logo" class="site-logo"></a></h1>
         <div class="user-container">
             <div id="user-info"></div>
         </div>

--- a/login.html
+++ b/login.html
@@ -5,6 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Login - MinTurnus</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter&family=Roboto&display=swap" rel="stylesheet">
+<link rel='icon' href='images/favicon.ico' sizes='any'>
+<link rel='icon' type='image/png' href='images/favicon.png'>
+<link rel='apple-touch-icon' href='images/icon-512.png'>
     <link rel="stylesheet" href="css/style.css">
     <link rel="stylesheet" href="css/header.css">
     <link rel="stylesheet" href="css/cookie-consent.css">
@@ -17,7 +20,7 @@
 </head>
 <body>
     <header class="header">
-        <h1><a href="index.html">Min<span class="accent-text">Turnus</span></a></h1>
+        <h1><a href="index.html"><img src="images/minturnus_logo.png" alt="MinTurnus-logo" class="site-logo"></a></h1>
         <div class="user-container">
             <div id="user-info"></div>
         </div>

--- a/register.html
+++ b/register.html
@@ -5,6 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Registrer deg - MinTurnus</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter&family=Roboto&display=swap" rel="stylesheet">
+<link rel='icon' href='images/favicon.ico' sizes='any'>
+<link rel='icon' type='image/png' href='images/favicon.png'>
+<link rel='apple-touch-icon' href='images/icon-512.png'>
     <link rel="stylesheet" href="css/style.css">
     <link rel="stylesheet" href="css/header.css">
     <link rel="stylesheet" href="css/cookie-consent.css">
@@ -14,7 +17,7 @@
 </head>
 <body>
     <header class="header">
-        <h1><a href="index.html">Min<span class="accent-text">Turnus</span></a></h1>
+        <h1><a href="index.html"><img src="images/minturnus_logo.png" alt="MinTurnus-logo" class="site-logo"></a></h1>
         <div class="user-container">
             <div id="user-info"></div>
         </div>

--- a/reset_password.html
+++ b/reset_password.html
@@ -5,6 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Tilbakestill Passord - MinTurnus</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter&family=Roboto&display=swap" rel="stylesheet">
+<link rel='icon' href='images/favicon.ico' sizes='any'>
+<link rel='icon' type='image/png' href='images/favicon.png'>
+<link rel='apple-touch-icon' href='images/icon-512.png'>
     <link rel="stylesheet" href="css/style.css">
     <link rel="stylesheet" href="css/header.css">
     <link rel="stylesheet" href="css/cookie-consent.css">
@@ -13,7 +16,7 @@
 </head>
 <body>
     <header class="header">
-        <h1><a href="index.html">Min<span class="accent-text">Turnus</span></a></h1>
+        <h1><a href="index.html"><img src="images/minturnus_logo.png" alt="MinTurnus-logo" class="site-logo"></a></h1>
         <div class="user-container">
             <div id="user-info"></div>
         </div>

--- a/user_profile.html
+++ b/user_profile.html
@@ -5,6 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Brukerprofil - MinTurnus</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter&family=Roboto&display=swap" rel="stylesheet">
+<link rel='icon' href='images/favicon.ico' sizes='any'>
+<link rel='icon' type='image/png' href='images/favicon.png'>
+<link rel='apple-touch-icon' href='images/icon-512.png'>
     <link rel="stylesheet" href="css/style.css">
     <link rel="stylesheet" href="css/header.css">
     <link rel="stylesheet" href="css/user_profile.css">
@@ -17,7 +20,7 @@
 </head>
 <body>
     <header class="header">
-        <h1><a href="index.html">Min<span class="accent-text">Turnus</span></a></h1>
+        <h1><a href="index.html"><img src="images/minturnus_logo.png" alt="MinTurnus-logo" class="site-logo"></a></h1>
         <div class="user-container">
             <div id="user-info"></div>
         </div>


### PR DESCRIPTION
## Summary
- add logo and favicon images
- include favicon and app icon tags in all pages
- show a logo image in each page header
- style `.site-logo` in the header
- remove image assets from repository
- keep an empty `images` directory for custom assets

## Testing
- `npm test` *(fails: Could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68544e6f0698833392e5a1b205e44804