### PR TITLE
Fix dayPopup initialization order

### DIFF
--- a/js/kalender.js
+++ b/js/kalender.js
@@ -895,12 +895,12 @@ function renderShiftList() {
 // Legg til ny turnus
 const maxShifts = 10; // Sett maksgrensen her
 
-// Initialiser kalenderen
-updateView();
-
 // ----- Dag-popup funksjonalitet -----
 const dayPopup = document.getElementById('day-popup');
 let outsideHandler = null;
+
+// Initialiser kalenderen
+updateView();
 
 function getShiftsForDate(date) {
     const result = [];


### PR DESCRIPTION
## Summary
- move `dayPopup` and `outsideHandler` variables above the initial call to `updateView`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6855b95b1bdc83338fd8127d6ec708bb