### PR TITLE
Improve day popup layout

### DIFF
--- a/css/calendar.css
+++ b/css/calendar.css
@@ -529,4 +529,17 @@ option {
     font-weight: bold;
 }
 
+.day-popup .popup-date {
+    font-weight: bold;
+    text-align: center;
+    margin-bottom: 5px;
+}
+
+.day-popup .turnus-item {
+    flex: 1 1 100%;
+    max-width: 100%;
+    min-width: 0;
+    margin-bottom: 4px;
+}
+
 

--- a/js/kalender.js
+++ b/js/kalender.js
@@ -155,6 +155,10 @@ const months = [
     'Juli', 'August', 'September', 'Oktober', 'November', 'Desember'
 ];
 
+const dayNames = [
+    'Søndag', 'Mandag', 'Tirsdag', 'Onsdag', 'Torsdag', 'Fredag', 'Lørdag'
+];
+
 document.addEventListener('DOMContentLoaded', function () {
     renderWeekdayRow();
     initializeEventListeners();
@@ -953,6 +957,11 @@ function showDayPopup(date, anchorEl) {
     closeSpan.textContent = '\u00d7';
     closeSpan.addEventListener('click', hideDayPopup);
     dayPopup.appendChild(closeSpan);
+
+    const header = document.createElement('div');
+    header.className = 'popup-date';
+    header.textContent = `${dayNames[date.getDay()]} ${date.getDate()}. ${months[date.getMonth()]}`;
+    dayPopup.appendChild(header);
 
     list.forEach(shift => {
         const item = document.createElement('div');


### PR DESCRIPTION
## Summary
- add `dayNames` constant
- show date in day popup header
- allow day popup items to fill width

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6855bca1c83c8333bb0597c5e0646503