### PR TITLE
Clarify manual shift form usage

### DIFF
--- a/css/calendar.css
+++ b/css/calendar.css
@@ -485,6 +485,25 @@ option {
     text-decoration: underline;
 }
 
+/* Informational box for the shift form */
+.info-box {
+    background-color: #fffbea;
+    border-left: 4px solid var(--accent-color);
+    padding: 10px;
+    border-radius: 4px;
+    margin-bottom: 15px;
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    font-size: 0.9rem;
+}
+
+.info-box .info-icon {
+    font-weight: bold;
+    font-size: 1.2rem;
+    line-height: 1;
+}
+
 .colleague-item input[type="checkbox"] {
     margin-right: 10px;
 }

--- a/index.html
+++ b/index.html
@@ -85,6 +85,10 @@
 
     <div class="shift-form">
         <h3>Legg til ny turnus manuelt</h3>
+        <div class="info-box">
+            <span class="info-icon">🛈</span>
+            <span>Dette skjemaet brukes til å legge til generelle turnuser i kalenderen. Ønsker du å lagre din egen turnus og dele med kollegaer? <a href="register.html">Opprett en profil her</a>.</span>
+        </div>
         
         <label for="shift-name">Navn på turnus:</label>
         <input type="text" id="shift-name" placeholder="Eks: Thomas">


### PR DESCRIPTION
## Summary
- make manual shift form header clearer with an info box
- add styles for the info box in calendar.css

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6855c8b13618833393b7ee116785a18f