### PR TITLE
Update README credentials section

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ MinTurnus is a small PHP and JavaScript web application for managing shifts and 
 
 Database and mail credentials are currently stored in `backend/database.php` and `backend/send_mail.php`. To keep sensitive data out of version control you can either create a `config.php` file or rely on environment variables.
 
+The file `backend/config.php` is ignored by Git and will not be present after cloning the repository. You must create it manually and define the variables before running the application.
+
 ### Using `config.php`
 
 Create a new file `backend/config.php` and define your settings:


### PR DESCRIPTION
## Summary
- clarify that `backend/config.php` is gitignored
- instruct users to create the file manually before running the app

## Testing
- `git status --short`
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6855d45c8f708333bd8f3ae8b2da573e