### PR TITLE
Add shift override functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,19 @@ Results are filtered with a fuzzy match. The query may match any part
 of a user's first or last name (split on spaces or hyphen) if the
 Levenshtein distance is one or the part starts with the query.
 
+## Shift overrides
+
+The calendar supports temporary overrides to any shift. An override
+defines a start date, a duration in days or weeks and an alternative
+shift pattern. When a date falls within an override period the
+specified pattern is used instead of the regular one and the day is
+highlighted in the calendar.
+
+Overrides can be added from the calendar page below the manual shift
+form. Fill in the shift name to override, choose the period and enter
+the replacement pattern (e.g. `2-2` or `D5-2`). Overrides appear in a
+list where they can be edited or removed.
+
 ### Creating the friends tables
 
 You can create the required tables manually or import the provided

--- a/css/calendar.css
+++ b/css/calendar.css
@@ -183,6 +183,20 @@
     border-radius: 50%;
 }
 
+.shift-override {
+    border: 2px solid #000;
+    position: relative;
+}
+
+.shift-override::after {
+    content: "★";
+    position: absolute;
+    top: -4px;
+    right: -4px;
+    font-size: 0.6rem;
+    color: #000;
+}
+
 
 .today {
     background-color: var(--accent-color);

--- a/index.html
+++ b/index.html
@@ -122,6 +122,38 @@
         <div id="message"></div>
     </div>
 
+    <form id="override-form" class="shift-form">
+        <h3>Legg til midlertidig overstyring</h3>
+        <label for="override-name">Navn på turnus:</label>
+        <input type="text" id="override-name" placeholder="Eks: Thomas">
+
+        <label for="override-start">Startdato</label>
+        <input type="date" id="override-start">
+
+        <label for="override-length">Varighet</label>
+        <input type="number" id="override-length" value="1" min="1">
+        <select id="override-unit">
+            <option value="days">Dager</option>
+            <option value="weeks">Uker</option>
+        </select>
+
+        <label for="override-pattern">Ny turnus</label>
+        <input type="text" id="override-pattern" placeholder="2-2">
+
+        <label for="override-color">Farge</label>
+        <input type="color" id="override-color">
+
+        <button type="button" id="add-override" class="btn">Lagre overstyring</button>
+    </form>
+
+    <div class="shift-list-header">
+        <span class="shift-header">Navn</span>
+        <span class="shift-header">Periode</span>
+        <span class="shift-header">Turnus</span>
+        <span class="shift-header">Handling</span>
+    </div>
+    <div id="override-list" class="shift-list"></div>
+
     <!-- Kolonnetitler for turnuslisten -->
     <div class="shift-list-header">
         <span class="shift-header">Velg</span>

--- a/js/kalender.js
+++ b/js/kalender.js
@@ -26,6 +26,7 @@ let colleagueColorPref = {};
 let closeColleagues = {};
 let currentUserFirstName = '';
 let initialColleagueMode = null;
+let shiftOverrides = [];
 const allColors = [
   "#FF6666", "#FFB266", "#FFFF66", "#B2FF66", "#66FFB2",
   "#66B2FF", "#CC66FF", "#FF66B2", "#66FF66", "#CCCCCC",
@@ -167,9 +168,11 @@ document.addEventListener('DOMContentLoaded', function () {
     loadColleagueColorPrefs();
     loadCloseColleagues();
     loadColleaguesList();
+    loadShiftOverrides();
     loadUserShift();
     renderCalendar(currentMonth, currentYear);
     renderShiftList();
+    renderOverrideList();
 });
 
 function initializeEventListeners() {
@@ -233,6 +236,9 @@ function initializeEventListeners() {
     if (btnAll) btnAll.addEventListener('click', () => setColleagueMode('all'));
     if (btnNone) btnNone.addEventListener('click', () => setColleagueMode('none'));
     if (btnClose) btnClose.addEventListener('click', () => setColleagueMode('close'));
+
+    const addOverrideBtn = document.getElementById('add-override');
+    if (addOverrideBtn) addOverrideBtn.addEventListener('click', addOrUpdateOverride);
 }
 
 
@@ -347,6 +353,49 @@ function addNewShift() {
 
 }
 
+function addOrUpdateOverride() {
+    const name = document.getElementById('override-name').value.trim();
+    const startInput = document.getElementById('override-start').value;
+    const durationVal = parseInt(document.getElementById('override-length').value, 10);
+    const unit = document.getElementById('override-unit').value;
+    const pattern = document.getElementById('override-pattern').value.trim();
+    const color = document.getElementById('override-color').value || null;
+
+    if (!name || !startInput || !durationVal || !pattern) return;
+    if (!/^(\d+-\d+|D\d+-\d+)$/.test(pattern)) return;
+
+    const startDate = new Date(startInput + 'T00:00:00');
+    const isDay = pattern.startsWith('D');
+    let work, off;
+    if (isDay) {
+        [work, off] = pattern.substring(1).split('-').map(Number);
+    } else {
+        [work, off] = pattern.split('-').map(Number);
+    }
+    const obj = {
+        name,
+        startDate,
+        duration: durationVal,
+        unit,
+        durationDays: durationVal * (unit === 'weeks' ? 7 : 1),
+        workWeeks: isDay ? work / 7 : work,
+        offWeeks: isDay ? off / 7 : off,
+        type: isDay ? 'dagbasert' : 'ukebasert',
+        raw: pattern,
+        color
+    };
+
+    if (editingOverride >= 0) {
+        shiftOverrides[editingOverride] = obj;
+        editingOverride = -1;
+    } else {
+        shiftOverrides.push(obj);
+    }
+    document.getElementById('override-form').reset();
+    renderOverrideList();
+    updateView();
+}
+
 
 // Funksjon for å slette en turnus
 function deleteShift(index) {
@@ -357,6 +406,25 @@ function deleteShift(index) {
     renderShiftList();
     updateView();
     updateTurnusOversikt();
+}
+
+let editingOverride = -1;
+
+function deleteOverride(index) {
+    shiftOverrides.splice(index, 1);
+    renderOverrideList();
+    updateView();
+}
+
+function editOverride(index) {
+    const o = shiftOverrides[index];
+    editingOverride = index;
+    document.getElementById('override-name').value = o.name;
+    document.getElementById('override-start').value = o.startDate.toISOString().slice(0,10);
+    document.getElementById('override-length').value = o.duration;
+    document.getElementById('override-unit').value = o.unit;
+    document.getElementById('override-pattern').value = o.raw || `${o.workWeeks}-${o.offWeeks}`;
+    if (o.color) document.getElementById('override-color').value = o.color;
 }
 
 // Laste eksisterende turnuser fra localStorage
@@ -405,6 +473,20 @@ function loadSelectedColleagues() {
 
 function saveSelectedColleagues() {
     localStorage.setItem('selectedColleagues', JSON.stringify(selectedColleagues));
+}
+
+function loadShiftOverrides() {
+    const stored = localStorage.getItem('shiftOverrides');
+    if (stored) {
+        shiftOverrides = JSON.parse(stored);
+        shiftOverrides.forEach(o => {
+            o.startDate = new Date(o.startDate);
+        });
+    }
+}
+
+function saveShiftOverrides() {
+    localStorage.setItem('shiftOverrides', JSON.stringify(shiftOverrides));
 }
 
 
@@ -738,36 +820,13 @@ function renderMonthInto(targetGrid, month, year, hideText = false) {
             dayElement.appendChild(specialText);
         }
 
-        shifts.forEach((shift) => {
-            if (!shift.visible) return;
-
-            if (shift.weekdays) {
-                const d = date.getDay();
-                if (d >= 1 && d <= 5) {
-                    const shiftBox = document.createElement('div');
-                    shiftBox.classList.add('shift-box');
-                    shiftBox.style.backgroundColor = shift.color;
-                    shiftContainer.appendChild(shiftBox);
-                }
-                return;
-            }
-
-            const daysSinceStart = Math.floor(
-                (Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()) -
-                 Date.UTC(shift.startDate.getFullYear(), shift.startDate.getMonth(), shift.startDate.getDate())) /
-                msPerDay
-            );
-            const extraDay = (shift.type === 'dagbasert' || shift.weekdays) ? 0 : 1;
-            const workDays = (shift.workWeeks * 7) + extraDay;
-            const cycleLength = (shift.workWeeks * 7) + (shift.offWeeks * 7);
-
-            let cyclePosition = ((daysSinceStart % cycleLength) + cycleLength) % cycleLength;
-            if (cyclePosition < workDays) {
-                const shiftBox = document.createElement('div');
-                shiftBox.classList.add('shift-box');
-                shiftBox.style.backgroundColor = shift.color;
-                shiftContainer.appendChild(shiftBox);
-            }
+        const list = getShiftsForDate(date);
+        list.forEach(shift => {
+            const shiftBox = document.createElement('div');
+            shiftBox.classList.add('shift-box');
+            if (shift.overrideActive) shiftBox.classList.add('shift-override');
+            shiftBox.style.backgroundColor = shift.color;
+            shiftContainer.appendChild(shiftBox);
         });
 
         targetGrid.appendChild(dayElement);
@@ -896,6 +955,26 @@ function renderShiftList() {
     saveShiftsToLocalStorage(); // Husk å lagre etter hver endring
 }
 
+function renderOverrideList() {
+    const list = document.getElementById('override-list');
+    if (!list) return;
+    list.innerHTML = '';
+    shiftOverrides.forEach((o, index) => {
+        const item = document.createElement('div');
+        item.className = 'shift-item';
+        const label = o.raw || `${o.workWeeks}-${o.offWeeks}`;
+        item.innerHTML = `
+            <span style="color:${o.color || '#000'}; font-weight:bold;">${o.name}</span>
+            <span>${o.startDate.toISOString().slice(0,10)} (${o.durationDays}d)</span>
+            <span>${label}</span>
+            <button onclick="editOverride(${index})">Rediger</button>
+            <button onclick="deleteOverride(${index})">Slett</button>
+        `;
+        list.appendChild(item);
+    });
+    saveShiftOverrides();
+}
+
 // Legg til ny turnus
 const maxShifts = 10; // Sett maksgrensen her
 
@@ -908,25 +987,50 @@ updateView();
 
 function getShiftsForDate(date) {
     const result = [];
+    const endOfDay = new Date(date.getFullYear(), date.getMonth(), date.getDate() + 1);
     shifts.forEach(shift => {
         if (!shift.visible) return;
 
-        if (shift.weekdays) {
+        let o = shiftOverrides.find(s => s.name === shift.name && date >= s.startDate && date < new Date(s.startDate.getTime() + s.durationDays * msPerDay));
+        let workWeeks = shift.workWeeks;
+        let offWeeks = shift.offWeeks;
+        let startDate = shift.startDate;
+        let type = shift.type;
+        let color = shift.color;
+        let raw = shift.raw;
+        let overrideActive = false;
+        if (o) {
+            workWeeks = o.workWeeks;
+            offWeeks = o.offWeeks;
+            startDate = o.startDate;
+            type = o.type;
+            raw = o.raw;
+            if (o.color) color = o.color;
+            overrideActive = true;
+        }
+
+        if (shift.weekdays && !overrideActive) {
             const d = date.getDay();
-            if (d >= 1 && d <= 5) result.push(shift);
+            if (d >= 1 && d <= 5) result.push(Object.assign({}, shift, {color}));
             return;
         }
 
         const daysSinceStart = Math.floor(
             (Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()) -
-             Date.UTC(shift.startDate.getFullYear(), shift.startDate.getMonth(), shift.startDate.getDate())) /
+             Date.UTC(startDate.getFullYear(), startDate.getMonth(), startDate.getDate())) /
             msPerDay
         );
-        const extraDay = (shift.type === 'dagbasert' || shift.weekdays) ? 0 : 1;
-        const workDays = (shift.workWeeks * 7) + extraDay;
-        const cycleLength = (shift.workWeeks * 7) + (shift.offWeeks * 7);
+        const extraDay = (type === 'dagbasert' || shift.weekdays) ? 0 : 1;
+        const workDays = (workWeeks * 7) + extraDay;
+        const cycleLength = (workWeeks * 7) + (offWeeks * 7);
         let cyclePos = ((daysSinceStart % cycleLength) + cycleLength) % cycleLength;
-        if (cyclePos < workDays) result.push(shift);
+        if (cyclePos < workDays) {
+            result.push({
+                name: shift.name,
+                workWeeks, offWeeks, startDate, color, type, raw,
+                overrideActive
+            });
+        }
     });
     return result;
 }
@@ -966,10 +1070,12 @@ function showDayPopup(date, anchorEl) {
     list.forEach(shift => {
         const item = document.createElement('div');
         item.className = 'turnus-item';
+        if (shift.overrideActive) item.classList.add('shift-override');
 
         const colorBox = document.createElement('div');
         colorBox.className = 'color-box';
         colorBox.style.backgroundColor = shift.color;
+        if (shift.overrideActive) colorBox.classList.add('shift-override');
 
         const span = document.createElement('span');
         const first = shift.name.split(' ')[0];


### PR DESCRIPTION
## Summary
- support temporary shift overrides stored in `localStorage`
- show and edit overrides in calendar page
- display overrides with a star icon using new `.shift-override` style
- document override feature

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6855d45b0dd48333917c1136b32d5fd8