### PR TITLE
Remove override and add user-specific deviations

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,18 +87,14 @@ Results are filtered with a fuzzy match. The query may match any part
 of a user's first or last name (split on spaces or hyphen) if the
 Levenshtein distance is one or the part starts with the query.
 
-## Shift overrides
+## Shift deviations
 
-The calendar supports temporary overrides to any shift. An override
-defines a start date, a duration in days or weeks and an alternative
-shift pattern. When a date falls within an override period the
-specified pattern is used instead of the regular one and the day is
-highlighted in the calendar.
-
-Overrides can be added from the calendar page below the manual shift
-form. Fill in the shift name to override, choose the period and enter
-the replacement pattern (e.g. `2-2` or `D5-2`). Overrides appear in a
-list where they can be edited or removed.
+Logged in users can register temporary deviations from their own shift.
+On the calendar page a button appears when your profile has a shift set.
+Choose a start date, a temporary pattern like `1-2` and whether the
+regular rhythm should continue unaffected or resume from the end of the
+deviation. Days affected by a deviation are highlighted with a thick
+border in the calendar.
 
 ### Creating the friends tables
 

--- a/css/calendar.css
+++ b/css/calendar.css
@@ -183,18 +183,20 @@
     border-radius: 50%;
 }
 
-.shift-override {
+.shift-deviation {
     border: 2px solid #000;
     position: relative;
 }
 
-.shift-override::after {
-    content: "★";
+.shift-deviation::after {
+    content: "";
     position: absolute;
     top: -4px;
     right: -4px;
-    font-size: 0.6rem;
-    color: #000;
+    width: 6px;
+    height: 6px;
+    background-color: #000;
+    border-radius: 50%;
 }
 
 

--- a/index.html
+++ b/index.html
@@ -122,37 +122,38 @@
         <div id="message"></div>
     </div>
 
-    <form id="override-form" class="shift-form">
-        <h3>Legg til midlertidig overstyring</h3>
-        <label for="override-name">Navn på turnus:</label>
-        <input type="text" id="override-name" placeholder="Eks: Thomas">
+    <button id="toggle-deviation" class="btn" style="display:none;">Legg til avvik fra turnus</button>
+    <form id="deviation-form" class="shift-form" style="display:none;">
+        <h3>Avvik fra egen turnus</h3>
+        <label for="deviation-start">Startdato</label>
+        <input type="date" id="deviation-start">
 
-        <label for="override-start">Startdato</label>
-        <input type="date" id="override-start">
-
-        <label for="override-length">Varighet</label>
-        <input type="number" id="override-length" value="1" min="1">
-        <select id="override-unit">
-            <option value="days">Dager</option>
-            <option value="weeks">Uker</option>
+        <label for="deviation-pattern">Midlertidig turnus</label>
+        <select id="deviation-pattern">
+            <option value="1-1">1-1</option>
+            <option value="1-2">1-2</option>
+            <option value="1-3">1-3</option>
+            <option value="1-4">1-4</option>
+            <option value="2-2">2-2</option>
+            <option value="2-3">2-3</option>
+            <option value="2-4">2-4</option>
+            <option value="2-6">2-6</option>
+            <option value="3-3">3-3</option>
+            <option value="3-4">3-4</option>
+            <option value="4-4">4-4</option>
+            <option value="4-5">4-5</option>
+            <option value="4-8">4-8</option>
+            <option value="5-5">5-5</option>
         </select>
 
-        <label for="override-pattern">Ny turnus</label>
-        <input type="text" id="override-pattern" placeholder="2-2">
+        <label for="deviation-behavior">Etter avvik</label>
+        <select id="deviation-behavior">
+            <option value="keep">Fortsett med original rytme</option>
+            <option value="shift">Fortsett fra slutten av avviket</option>
+        </select>
 
-        <label for="override-color">Farge</label>
-        <input type="color" id="override-color">
-
-        <button type="button" id="add-override" class="btn">Lagre overstyring</button>
+        <button type="button" id="save-deviation" class="btn">Lagre avvik</button>
     </form>
-
-    <div class="shift-list-header">
-        <span class="shift-header">Navn</span>
-        <span class="shift-header">Periode</span>
-        <span class="shift-header">Turnus</span>
-        <span class="shift-header">Handling</span>
-    </div>
-    <div id="override-list" class="shift-list"></div>
 
     <!-- Kolonnetitler for turnuslisten -->
     <div class="shift-list-header">


### PR DESCRIPTION
## Summary
- revert generic override commit
- let logged-in users add personal shift deviations
- store deviations in local storage and highlight them on the calendar
- document shift deviation feature in README

## Testing
- `node -e "require('./js/kalender.js')"` *(fails: document not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6855d90f677c8333badb9c8eb448f4c1