### PR TITLE
Add deviation list and new shift patterns

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,6 +83,44 @@
             </div>
         </div>
 
+    <div id="deviation-section">
+        <button id="toggle-deviation" class="btn" style="display:none;">Legg til avvik fra turnus</button>
+        <form id="deviation-form" class="shift-form" style="display:none;">
+            <h3>Avvik fra egen turnus</h3>
+            <label for="deviation-start">Startdato</label>
+            <input type="date" id="deviation-start">
+
+            <label for="deviation-pattern">Midlertidig turnus</label>
+            <select id="deviation-pattern">
+                <option value="1-1">1-1</option>
+                <option value="1-2">1-2</option>
+                <option value="1-3">1-3</option>
+                <option value="1-4">1-4</option>
+                <option value="2-1">2-1</option>
+                <option value="2-2">2-2</option>
+                <option value="2-3">2-3</option>
+                <option value="2-4">2-4</option>
+                <option value="2-6">2-6</option>
+                <option value="3-1">3-1</option>
+                <option value="3-2">3-2</option>
+                <option value="3-3">3-3</option>
+                <option value="3-4">3-4</option>
+                <option value="4-4">4-4</option>
+                <option value="4-5">4-5</option>
+                <option value="4-8">4-8</option>
+                <option value="5-5">5-5</option>
+            </select>
+
+            <label for="deviation-behavior">Etter avvik</label>
+            <select id="deviation-behavior">
+                <option value="keep">Fortsett med original rytme</option>
+                <option value="shift">Fortsett fra slutten av avviket</option>
+            </select>
+
+            <button type="button" id="save-deviation" class="btn">Lagre avvik</button>
+        </form>
+        <div id="deviation-list" class="shift-list"></div>
+    </div>
     <div class="shift-form">
         <h3>Legg til ny turnus manuelt</h3>
         <div class="info-box">
@@ -96,14 +134,18 @@
         <label for="shift-duration">Turnus lengde:</label>
         <select id="shift-duration">
             <!-- Forhåndsdefinerte turnuser -->
+            <option value="mandag-fredag">Mandag til fredag</option>
             <option value="1-1">1-1</option>
             <option value="1-2">1-2</option>
             <option value="1-3">1-3</option>
             <option value="1-4">1-4</option>
+            <option value="2-1">2-1</option>
             <option value="2-2">2-2</option>
             <option value="2-3">2-3</option>
             <option value="2-4">2-4</option>
             <option value="2-6">2-6</option>
+            <option value="3-1">3-1</option>
+            <option value="3-2">3-2</option>
             <option value="3-3">3-3</option>
             <option value="3-4">3-4</option>
             <option value="4-4">4-4</option>
@@ -122,38 +164,6 @@
         <div id="message"></div>
     </div>
 
-    <button id="toggle-deviation" class="btn" style="display:none;">Legg til avvik fra turnus</button>
-    <form id="deviation-form" class="shift-form" style="display:none;">
-        <h3>Avvik fra egen turnus</h3>
-        <label for="deviation-start">Startdato</label>
-        <input type="date" id="deviation-start">
-
-        <label for="deviation-pattern">Midlertidig turnus</label>
-        <select id="deviation-pattern">
-            <option value="1-1">1-1</option>
-            <option value="1-2">1-2</option>
-            <option value="1-3">1-3</option>
-            <option value="1-4">1-4</option>
-            <option value="2-2">2-2</option>
-            <option value="2-3">2-3</option>
-            <option value="2-4">2-4</option>
-            <option value="2-6">2-6</option>
-            <option value="3-3">3-3</option>
-            <option value="3-4">3-4</option>
-            <option value="4-4">4-4</option>
-            <option value="4-5">4-5</option>
-            <option value="4-8">4-8</option>
-            <option value="5-5">5-5</option>
-        </select>
-
-        <label for="deviation-behavior">Etter avvik</label>
-        <select id="deviation-behavior">
-            <option value="keep">Fortsett med original rytme</option>
-            <option value="shift">Fortsett fra slutten av avviket</option>
-        </select>
-
-        <button type="button" id="save-deviation" class="btn">Lagre avvik</button>
-    </form>
 
     <!-- Kolonnetitler for turnuslisten -->
     <div class="shift-list-header">

--- a/js/kalender.js
+++ b/js/kalender.js
@@ -75,9 +75,7 @@ function saveShiftDeviations() {
   localStorage.setItem('shiftDeviations', JSON.stringify(shiftDeviations));
 }
 const predefinedShifts = [
-    '1-1', '1-2', '1-3', '1-4', '2-2', '2-3', '2-4', '2-6', 
-    '3-3', '3-4', '4-4', '4-5', '4-8', '5-5'
-]; 
+    'mandag-fredag', '1-1', '1-2', '1-3', '1-4', '2-1', '2-2', '2-3', '2-4', '2-6', '3-1', '3-2', '3-3', '3-4', '4-4', '4-5', '4-8', '5-5']; 
 
 const redDays = [
     { name: '1.Nyttårsdag', date: '01-01' },
@@ -182,6 +180,7 @@ document.addEventListener('DOMContentLoaded', function () {
     loadColleagueColorPrefs();
     loadCloseColleagues();
     loadShiftDeviations();
+    renderDeviationList();
     loadColleaguesList();
     loadUserShift();
     renderCalendar(currentMonth, currentYear);
@@ -255,11 +254,9 @@ function initializeEventListeners() {
     if (toggleDev) {
         toggleDev.addEventListener('click', () => {
             const form = document.getElementById('deviation-form');
-            if (form.style.display === 'none' || form.style.display === '') {
-                form.style.display = 'block';
-            } else {
-                form.style.display = 'none';
-            }
+            const show = form.style.display === 'none' || form.style.display === '';
+            form.style.display = show ? 'block' : 'none';
+            toggleDev.textContent = show ? 'Lukk skjema for avvik fra turnus' : 'Legg til avvik fra turnus';
         });
     }
     if (saveDev) saveDev.addEventListener('click', addDeviation);
@@ -394,7 +391,38 @@ function addDeviation() {
     });
     saveShiftDeviations();
     document.getElementById('deviation-form').reset();
+    renderDeviationList();
     updateView();
+}
+
+function deleteDeviation(index) {
+    shiftDeviations.splice(index, 1);
+    saveShiftDeviations();
+    renderDeviationList();
+    updateView();
+}
+
+function renderDeviationList() {
+    const list = document.getElementById('deviation-list');
+    if (!list) return;
+    list.innerHTML = '';
+    shiftDeviations.forEach((d, idx) => {
+        const item = document.createElement('div');
+        item.className = 'shift-item';
+        const start = d.startDate.toISOString().slice(0, 10);
+        const pattern = `${d.workWeeks}-${d.offWeeks}`;
+        const span1 = document.createElement('span');
+        span1.textContent = start;
+        const span2 = document.createElement('span');
+        span2.textContent = pattern;
+        const btn = document.createElement('button');
+        btn.textContent = 'Fjern';
+        btn.addEventListener('click', () => deleteDeviation(idx));
+        item.appendChild(span1);
+        item.appendChild(span2);
+        item.appendChild(btn);
+        list.appendChild(item);
+    });
 }
 
 

--- a/user_profile.html
+++ b/user_profile.html
@@ -91,11 +91,14 @@
                             <option value="1-2">1-2</option>
                             <option value="1-3">1-3</option>
                             <option value="1-4">1-4</option>
+                            <option value="2-1">2-1</option>
                             <option value="2-2">2-2</option>
                             <option value="2-3">2-3</option>
                             <option value="2-4">2-4</option>
                             <option value="2-6">2-6</option>
                             <option value="2-10">2-10</option>
+                            <option value="3-1">3-1</option>
+                            <option value="3-2">3-2</option>
                             <option value="3-3">3-3</option>
                             <option value="4-4">4-4</option>
                             <option value="4-5">4-5</option>


### PR DESCRIPTION
## Summary
- let users add Monday-Friday and new patterns 2-1, 3-1 and 3-2 when creating shifts or editing profiles
- move deviation form above manual shifts and allow toggling button text
- show a list of registered deviations with the ability to remove them

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_6855de4ae6208333a5f1f07db7293c85