### PR TITLE
Fix deviation date offset and hide manual info

### DIFF
--- a/css/calendar.css
+++ b/css/calendar.css
@@ -199,6 +199,28 @@
     border-radius: 50%;
 }
 
+.container.year-view .shift-deviation {
+    border-width: 1px;
+}
+.container.year-view .shift-deviation::after {
+    top: -2px;
+    right: -2px;
+    width: 4px;
+    height: 4px;
+}
+
+@media (max-width: 600px) {
+    .shift-deviation {
+        border-width: 1px;
+    }
+    .shift-deviation::after {
+        top: -2px;
+        right: -2px;
+        width: 4px;
+        height: 4px;
+    }
+}
+
 
 .today {
     background-color: var(--accent-color);

--- a/index.html
+++ b/index.html
@@ -123,7 +123,7 @@
     </div>
     <div class="shift-form">
         <h3>Legg til ny turnus manuelt</h3>
-        <div class="info-box">
+        <div class="info-box" id="manual-shift-info">
             <span class="info-icon">🛈</span>
             <span>Dette skjemaet brukes til å legge til generelle turnuser i kalenderen. Ønsker du å lagre din egen turnus og dele med kollegaer? <a href="register.html">Opprett en profil her</a>.</span>
         </div>

--- a/js/kalender.js
+++ b/js/kalender.js
@@ -77,7 +77,7 @@ function loadShiftDeviations() {
     .then(list => {
       shiftDeviations = list.map(d => ({
         id: d.id,
-        startDate: new Date(d.start_date),
+        startDate: new Date(d.start_date + 'T00:00'),
         workWeeks: parseInt(d.work_weeks, 10),
         offWeeks: parseInt(d.off_weeks, 10),
         durationDays: parseInt(d.duration_days, 10),
@@ -91,14 +91,19 @@ function loadShiftDeviations() {
       const s = localStorage.getItem('shiftDeviations');
       if (s) {
         shiftDeviations = JSON.parse(s);
-        shiftDeviations.forEach(d => d.startDate = new Date(d.startDate));
+        shiftDeviations.forEach(d => d.startDate = new Date(d.startDate + 'T00:00'));
       }
     });
 }
 
 function saveShiftDeviations() {
   // persisted via API; localStorage acts as cache
-  localStorage.setItem('shiftDeviations', JSON.stringify(shiftDeviations));
+  const cache = shiftDeviations.map(d => {
+    const local = new Date(d.startDate.getTime() - d.startDate.getTimezoneOffset() * 60000)
+                      .toISOString().split('T')[0];
+    return Object.assign({}, d, { startDate: local });
+  });
+  localStorage.setItem('shiftDeviations', JSON.stringify(cache));
 }
 const predefinedShifts = [
     'mandag-fredag', '1-1', '1-2', '1-3', '1-4', '2-1', '2-2', '2-3', '2-4', '2-6', '3-1', '3-2', '3-3', '3-4', '4-4', '4-5', '4-8', '5-5']; 
@@ -462,7 +467,8 @@ function renderDeviationList() {
     shiftDeviations.forEach((d, idx) => {
         const item = document.createElement('div');
         item.className = 'shift-item';
-        const start = d.startDate.toISOString().slice(0, 10);
+        const start = new Date(d.startDate.getTime() - d.startDate.getTimezoneOffset() * 60000)
+                        .toISOString().split('T')[0];
         const pattern = `${d.workWeeks}-${d.offWeeks}`;
         const span1 = document.createElement('span');
         span1.textContent = start;

--- a/js/session.js
+++ b/js/session.js
@@ -26,6 +26,7 @@ document.addEventListener('DOMContentLoaded', async function () {
     const loginLink = document.getElementById('login-link');
     const pendingBadge = document.getElementById('pending-count');
     const colleagueSection = document.getElementById('colleague-section');
+    const manualShiftInfo = document.getElementById('manual-shift-info');
 
     // Håndter innloggingsstatus
     if (userName) {
@@ -39,6 +40,7 @@ document.addEventListener('DOMContentLoaded', async function () {
         if (profileItem) profileItem.style.display = 'list-item';
         if (pendingBadge) pendingBadge.style.display = 'inline';
         if (colleagueSection) colleagueSection.style.display = 'block';
+        if (manualShiftInfo) manualShiftInfo.style.display = 'none';
 
         // Skjul "Logg inn"-lenken når brukeren er logget inn
         if (loginLink) {
@@ -54,6 +56,7 @@ document.addEventListener('DOMContentLoaded', async function () {
         if (loginLink) loginLink.style.display = 'list-item';
         if (pendingBadge) pendingBadge.style.display = 'none';
         if (colleagueSection) colleagueSection.style.display = 'none';
+        if (manualShiftInfo) manualShiftInfo.style.display = 'block';
     }
 
     // Global event listener for utlogging


### PR DESCRIPTION
## Summary
- parse deviation dates as local time
- cache deviations with local dates
- display deviation start dates without timezone shifts
- reduce border thickness for deviation circles in year/mobile view
- hide manual shift info for logged-in users

## Testing
- `npm test` *(fails: Could not read package.json)*
- `composer test` *(fails: command not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6855e593c9908333b4c20c21448fbd48