### PR TITLE
Support skipping weeks in shift deviation

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,6 +92,11 @@
 
             <label for="deviation-pattern">Midlertidig turnus</label>
             <select id="deviation-pattern">
+                <option value="0-1">0-1</option>
+                <option value="0-2">0-2</option>
+                <option value="0-3">0-3</option>
+                <option value="0-4">0-4</option>
+                <option value="0-5">0-5</option>
                 <option value="1-1">1-1</option>
                 <option value="1-2">1-2</option>
                 <option value="1-3">1-3</option>

--- a/js/kalender.js
+++ b/js/kalender.js
@@ -1062,7 +1062,7 @@ function getShiftsForDate(date) {
              Date.UTC(startDate.getFullYear(), startDate.getMonth(), startDate.getDate())) /
             msPerDay
         );
-        const extraDay = (type === 'dagbasert' || shift.weekdays) ? 0 : 1;
+        const extraDay = (type === 'dagbasert' || shift.weekdays || workWeeks === 0) ? 0 : 1;
         const workDays = (workWeeks * 7) + extraDay;
         const cycleLength = (workWeeks * 7) + (offWeeks * 7);
         let cyclePos = ((daysSinceStart % cycleLength) + cycleLength) % cycleLength;


### PR DESCRIPTION
## Summary
- add 0‑N choices for shift deviation pattern so weeks can be skipped
- ignore the extra day when workWeeks equals 0 in calendar logic

## Testing
- `node --check js/kalender.js`

------
https://chatgpt.com/codex/tasks/task_e_6855e7f5ede8833387b22b3ed173e55c