### PR TITLE
Add automatic cache reset on version change

### DIFF
--- a/js/kalender.js
+++ b/js/kalender.js
@@ -1,3 +1,15 @@
+// Handle localStorage versioning for shift and color data
+const APP_VERSION = '1.0'; // Increase when releasing a new version
+const savedVersion = localStorage.getItem('appVersion');
+if (savedVersion !== APP_VERSION) {
+  localStorage.removeItem('shifts');
+  localStorage.removeItem('availableColors');
+  localStorage.setItem('appVersion', APP_VERSION);
+  if (savedVersion !== null) {
+    location.reload();
+  }
+}
+
 // JavaScript for kalenderen
 const currentDate = new Date();
 let currentMonth = currentDate.getMonth();


### PR DESCRIPTION
## Summary
- add a simple version check at the top of `kalender.js`
- remove `shifts` and `availableColors` from `localStorage` when the version changes
- store the new version and reload the page once

## Testing
- `npm test` *(fails: could not find `package.json`)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6855eb55c6888333befafee6c0eac9c4