### PR TITLE
Fix about page update without placeholder images

### DIFF
--- a/about.html
+++ b/about.html
@@ -36,6 +36,10 @@
         <main class="about-box">
             <h1 class="page-title">Om MinTurnus</h1>
 
+            <section class="section personal-intro">
+                <p>Jeg har lenge hatt behov for å samle oversikt over turnuser for å lettere planlegge turer og aktiviteter med venner og familie. Det er utfordrende å finne tid sammen når mange i nettverket mitt jobber turnus. Dette verktøyet ble skapt for å gjøre akkurat det enklere – å finne åpninger i en travel hverdag.</p>
+            </section>
+
             <section class="section">
                 <p>MinTurnus er et gratis nettbasert hjelpemiddel for alle som jobber turnus. Her kan du samle dine egne skift i en oversiktlig kalender og enkelt dele planene med venner og kollegaer.</p>
             </section>
@@ -48,17 +52,32 @@
             <section class="section">
                 <h2>Hovedfunksjoner</h2>
                 <ul class="feature-list">
-                    <li>Registrer og vis din egen turnus direkte i nettleseren.</li>
-                    <li>Inviter kollegaer og del skiftplaner med hverandre.</li>
-                    <li>Marker nære kollegaer for rask tilgang.</li>
-                    <li>Angi midlertidige avvik som ferie eller bytte av skift.</li>
-                    <li>Data lagres trygt på serveren slik at den følger deg på tvers av enheter.</li>
+                    <li><span class="feature-icon">&#10003;</span>Registrer og vis din egen turnus direkte i nettleseren.</li>
+                    <li><span class="feature-icon">&#10003;</span>Inviter kollegaer og del skiftplaner med hverandre.</li>
+                    <li><span class="feature-icon">&#10003;</span>Marker nære kollegaer for rask tilgang.</li>
+                    <li><span class="feature-icon">&#10003;</span>Angi midlertidige avvik som ferie eller bytte av skift.</li>
+                    <li><span class="feature-icon">&#10003;</span>Data lagres trygt på serveren slik at den følger deg på tvers av enheter.</li>
                 </ul>
+            </section>
+
+            <section class="section">
+                <h2>Eksempel</h2>
+                <p>Dette er et eksempel på hvordan turnusvisning kan se ut i MinTurnus.</p>
+                <img src="images/hele.png" alt="Eksempel på turnusoversikt" class="example-image">
+                <div class="example-caption">Årsoversikt hvor neste ledige helg er 22. november 2025.</div>
+                <img src="images/november.png" alt="Månedsvisning med ledige dager" class="example-image">
+                <div class="example-caption">Månedsvisning som viser at 22. og 23. november er ledige.</div>
             </section>
 
             <section class="section">
                 <h2>Veien videre</h2>
                 <p>Prosjektet utvikles fortløpende og tilbakemeldinger mottas med takk.</p>
+            </section>
+
+            <section class="cta-section">
+                <h2>Bli med i dag</h2>
+                <p>Opprett en gratis konto og prøv MinTurnus selv.</p>
+                <a href="register.html" class="btn">Registrer deg</a>
             </section>
         </main>
 

--- a/css/style.css
+++ b/css/style.css
@@ -169,7 +169,7 @@ h2 {
 }
 
 .about-box {
-    max-width: 600px;
+    max-width: 700px;
     margin: 40px auto;
     padding: 30px;
     background-color: var(--card-bg);
@@ -188,21 +188,62 @@ h2 {
 }
 
 .feature-list li {
-    position: relative;
-    padding-left: 1.5rem;
+    display: flex;
+    align-items: flex-start;
     margin-bottom: 0.5rem;
 }
 
-.feature-list li::before {
-    content: "\2713";
-    position: absolute;
-    left: 0;
-    margin-right: 0.5em;
-    color: #4CAF50;
+.feature-icon {
+    margin-right: 0.5rem;
+    font-size: 1.2rem;
+    color: var(--accent-color);
+    line-height: 1.4;
 }
 
 section {
     margin-bottom: 1.5rem;
+}
+
+/* Personlig introduksjon */
+.personal-intro {
+    background-color: #f9f9f9;
+    border-left: 4px solid var(--accent-color);
+    padding: 1rem;
+    margin-bottom: 2rem;
+}
+
+/* Eksempelbilder */
+.example-image {
+    width: 100%;
+    border: 2px solid var(--secondary-color);
+    border-radius: var(--border-radius);
+    margin-top: 1rem;
+}
+
+.example-caption {
+    text-align: center;
+    font-size: 0.9rem;
+    margin-top: 0.5rem;
+    color: #555;
+}
+
+/* Call to action */
+.cta-section {
+    background-color: var(--accent-color);
+    text-align: center;
+    padding: 2rem 1rem;
+    border-radius: var(--border-radius);
+    margin-top: 2rem;
+}
+
+.cta-section h2 {
+    color: var(--primary-color);
+    margin-bottom: 1rem;
+}
+
+.cta-section .btn {
+    width: auto;
+    padding: 12px 30px;
 }
 
 /* Styling for Kontakt Oss Section */


### PR DESCRIPTION
## Summary
- remove placeholder PNG images mistakenly added
- keep about page improvements for personal intro, features, examples and call-to-action

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68569b62f75483338a64af3589b7a301