### PR TITLE
Add request notification bell for mobile

### DIFF
--- a/about.html
+++ b/about.html
@@ -19,8 +19,9 @@
     <header class="header">
         <h1><a href="index.html">Min<span class="accent-text">Turnus</span></a></h1>
         <div class="user-container">
-            <div id="user-info"></div>
+        <div id="user-info"></div>
         </div>
+        <div id="request-bell" class="request-bell">&#128276;<span id="request-count" class="badge"></span></div>
         <div id="hamburger" class="hamburger">&#9776;</div>
     </header>
 

--- a/change_password.html
+++ b/change_password.html
@@ -20,8 +20,9 @@
     <header class="header">
         <h1><a href="index.html">Min<span class="accent-text">Turnus</span></a></h1>
         <div class="user-container">
-            <div id="user-info"></div>
+        <div id="user-info"></div>
         </div>
+        <div id="request-bell" class="request-bell">&#128276;<span id="request-count" class="badge"></span></div>
         <div id="hamburger" class="hamburger">&#9776;</div>
     </header>
 

--- a/contact.html
+++ b/contact.html
@@ -20,8 +20,9 @@
     <header class="header">
         <h1><a href="index.html">Min<span class="accent-text">Turnus</span></a></h1>
         <div class="user-container">
-            <div id="user-info"></div>
+        <div id="user-info"></div>
         </div>
+        <div id="request-bell" class="request-bell">&#128276;<span id="request-count" class="badge"></span></div>
         <div id="hamburger" class="hamburger">&#9776;</div>
     </header>
 

--- a/css/header.css
+++ b/css/header.css
@@ -104,6 +104,17 @@
     display: none;
 }
 
+/* Notification bell for friend requests */
+.request-bell {
+    display: none;
+    position: absolute;
+    left: 20px;
+    top: 15px;
+    font-size: 26px;
+    color: var(--light-color);
+    cursor: pointer;
+}
+
 @media (max-width: 768px) {
     .header {
         padding: 15px;
@@ -146,5 +157,9 @@
         right: 20px;
         background: none;
         border: none;
+    }
+
+    .request-bell {
+        display: block;
     }
 }

--- a/forgot_password.html
+++ b/forgot_password.html
@@ -18,8 +18,9 @@
     <header class="header">
         <h1><a href="index.html">Min<span class="accent-text">Turnus</span></a></h1>
         <div class="user-container">
-            <div id="user-info"></div>
+        <div id="user-info"></div>
         </div>
+        <div id="request-bell" class="request-bell">&#128276;<span id="request-count" class="badge"></span></div>
         <div id="hamburger" class="hamburger">&#9776;</div>
     </header>
 

--- a/friends.html
+++ b/friends.html
@@ -25,6 +25,7 @@
     <div class="user-container">
         <div id="user-info"></div>
     </div>
+    <div id="request-bell" class="request-bell">&#128276;<span id="request-count" class="badge"></span></div>
     <div id="hamburger" class="hamburger">&#9776;</div>
 </header>
 

--- a/index.html
+++ b/index.html
@@ -23,8 +23,9 @@
     <header class="header">
         <h1><a href="index.html">Min<span class="accent-text">Turnus</span></a></h1>
         <div class="user-container">
-            <div id="user-info"></div>
+        <div id="user-info"></div>
         </div>
+        <div id="request-bell" class="request-bell">&#128276;<span id="request-count" class="badge"></span></div>
         <div id="hamburger" class="hamburger">&#9776;</div>
     </header>
         <nav id="navbar" class="navbar">

--- a/js/session.js
+++ b/js/session.js
@@ -25,6 +25,8 @@ document.addEventListener('DOMContentLoaded', async function () {
     const profileItem = document.getElementById('profile-item');
     const loginLink = document.getElementById('login-link');
     const pendingBadge = document.getElementById('pending-count');
+    const requestBell = document.getElementById('request-bell');
+    const requestCount = document.getElementById('request-count');
     const colleagueSection = document.getElementById('colleague-section');
     const manualShiftInfo = document.getElementById('manual-shift-info');
 
@@ -39,6 +41,7 @@ document.addEventListener('DOMContentLoaded', async function () {
         if (friendsItem) friendsItem.style.display = 'list-item';
         if (profileItem) profileItem.style.display = 'list-item';
         if (pendingBadge) pendingBadge.style.display = 'inline';
+        if (requestBell) requestBell.style.display = 'none';
         if (colleagueSection) colleagueSection.style.display = 'block';
         if (manualShiftInfo) manualShiftInfo.style.display = 'none';
 
@@ -55,6 +58,7 @@ document.addEventListener('DOMContentLoaded', async function () {
         // Sørg for at "Logg inn"-lenken vises
         if (loginLink) loginLink.style.display = 'list-item';
         if (pendingBadge) pendingBadge.style.display = 'none';
+        if (requestBell) requestBell.style.display = 'none';
         if (colleagueSection) colleagueSection.style.display = 'none';
         if (manualShiftInfo) manualShiftInfo.style.display = 'block';
     }
@@ -84,7 +88,13 @@ document.addEventListener('DOMContentLoaded', async function () {
         });
     }
 
-    if (pendingBadge) {
+    if (requestBell) {
+        requestBell.addEventListener('click', function () {
+            window.location.href = 'friends.html';
+        });
+    }
+
+    if (pendingBadge || requestCount) {
         updatePendingBadge();
         setInterval(updatePendingBadge, 60000);
     }
@@ -92,19 +102,26 @@ document.addEventListener('DOMContentLoaded', async function () {
 
 async function updatePendingBadge() {
     const badge = document.getElementById('pending-count');
-    if (!badge) return;
+    const bellBadge = document.getElementById('request-count');
+    const requestBell = document.getElementById('request-bell');
+    if (!badge && !bellBadge) return;
     try {
         const res = await fetch('api/pending_count.php', { credentials: 'include' });
         if (!res.ok) {
-            badge.style.display = 'none';
+            if (badge) badge.style.display = 'none';
+            if (bellBadge) bellBadge.style.display = 'none';
+            if (requestBell) requestBell.style.display = 'none';
             return;
         }
         const data = await res.json();
         if (data.count > 0) {
-            badge.textContent = data.count;
-            badge.style.display = 'block';
+            if (badge) { badge.textContent = data.count; badge.style.display = 'block'; }
+            if (bellBadge) { bellBadge.textContent = data.count; bellBadge.style.display = 'block'; }
+            if (requestBell) requestBell.style.display = 'block';
         } else {
-            badge.style.display = 'none';
+            if (badge) badge.style.display = 'none';
+            if (bellBadge) bellBadge.style.display = 'none';
+            if (requestBell) requestBell.style.display = 'none';
         }
     } catch (e) {
         console.error('Failed to fetch pending count:', e);

--- a/login.html
+++ b/login.html
@@ -22,8 +22,9 @@
     <header class="header">
         <h1><a href="index.html">Min<span class="accent-text">Turnus</span></a></h1>
         <div class="user-container">
-            <div id="user-info"></div>
+        <div id="user-info"></div>
         </div>
+        <div id="request-bell" class="request-bell">&#128276;<span id="request-count" class="badge"></span></div>
         <div id="hamburger" class="hamburger">&#9776;</div>
     </header>
         <nav id="navbar" class="navbar">

--- a/register.html
+++ b/register.html
@@ -19,8 +19,9 @@
     <header class="header">
         <h1><a href="index.html">Min<span class="accent-text">Turnus</span></a></h1>
         <div class="user-container">
-            <div id="user-info"></div>
+        <div id="user-info"></div>
         </div>
+        <div id="request-bell" class="request-bell">&#128276;<span id="request-count" class="badge"></span></div>
         <div id="hamburger" class="hamburger">&#9776;</div>
     </header>
     

--- a/reset_password.html
+++ b/reset_password.html
@@ -18,8 +18,9 @@
     <header class="header">
         <h1><a href="index.html">Min<span class="accent-text">Turnus</span></a></h1>
         <div class="user-container">
-            <div id="user-info"></div>
+        <div id="user-info"></div>
         </div>
+        <div id="request-bell" class="request-bell">&#128276;<span id="request-count" class="badge"></span></div>
         <div id="hamburger" class="hamburger">&#9776;</div>
     </header>
 

--- a/user_profile.html
+++ b/user_profile.html
@@ -22,8 +22,9 @@
     <header class="header">
         <h1><a href="index.html">Min<span class="accent-text">Turnus</span></a></h1>
         <div class="user-container">
-            <div id="user-info"></div>
+        <div id="user-info"></div>
         </div>
+        <div id="request-bell" class="request-bell">&#128276;<span id="request-count" class="badge"></span></div>
         <div id="hamburger" class="hamburger">&#9776;</div>
     </header>
 


### PR DESCRIPTION
## Summary
- add a small bell icon in header of all pages
- show/hide the bell with number of pending colleague requests
- update CSS for bell icon
- extend session.js to update badge and navigate to friends page when tapped

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6856ce94f0588333a3444076a09036a7