### PR TITLE
Prevent duplicate colleague requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,8 @@ CREATE TABLE `friend_requests` (
   `status` TINYINT NOT NULL DEFAULT 0,
   `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   KEY `sender_id` (`sender_id`),
-  KEY `receiver_id` (`receiver_id`)
+  KEY `receiver_id` (`receiver_id`),
+  UNIQUE KEY `unique_pair` (`sender_id`, `receiver_id`)
 );
 
 CREATE TABLE `friends` (

--- a/api/send_request.php
+++ b/api/send_request.php
@@ -19,6 +19,24 @@ if ($receiver <= 0 || $receiver === $sender) {
     exit;
 }
 
+$check = $conn->prepare('SELECT 1 FROM friend_requests WHERE sender_id = ? AND receiver_id = ? AND status = 0');
+$check->bind_param('ii', $sender, $receiver);
+$check->execute();
+$check->store_result();
+if ($check->num_rows > 0) {
+    echo json_encode(['status' => 'error', 'message' => 'Allerede sendt']);
+    exit;
+}
+
+$friend = $conn->prepare('SELECT 1 FROM friends WHERE (user1 = ? AND user2 = ?) OR (user1 = ? AND user2 = ?)');
+$friend->bind_param('iiii', $sender, $receiver, $receiver, $sender);
+$friend->execute();
+$friend->store_result();
+if ($friend->num_rows > 0) {
+    echo json_encode(['status' => 'error', 'message' => 'Allerede kollegaer']);
+    exit;
+}
+
 $stmt = $conn->prepare("INSERT INTO friend_requests (sender_id, receiver_id, status) VALUES (?, ?, 0)");
 if (!$stmt) {
     http_response_code(500);

--- a/schema.sql
+++ b/schema.sql
@@ -8,7 +8,8 @@ CREATE TABLE `friend_requests` (
   `status` TINYINT NOT NULL DEFAULT 0,
   `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   KEY `sender_id` (`sender_id`),
-  KEY `receiver_id` (`receiver_id`)
+  KEY `receiver_id` (`receiver_id`),
+  UNIQUE KEY `unique_pair` (`sender_id`, `receiver_id`)
 );
 
 -- Table storing confirmed colleague relations


### PR DESCRIPTION
## Summary
- prevent duplicate colleague requests server-side
- add unique constraint in schema and documentation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68571708191c8333bed4b7ddfcd7fbdd