### PR TITLE
Fix re-adding colleagues

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ All endpoints require the user to be logged in via PHP sessions.
 | `api/pending_requests.php` | GET | List incoming colleague requests. |
 | `api/respond_request.php` | POST | Accept or decline a request. JSON body `{id, accept}`. |
 | `api/my_colleagues.php` | GET | List confirmed colleagues. |
-| `api/remove_colleague.php` | DELETE | Remove a colleague. JSON body `{id}`. |
+| `api/remove_colleague.php` | DELETE | Remove a colleague. JSON body `{id}`. Any associated request entry is also deleted so a new request can be made. |
 
 These scripts expect the tables `friend_requests` and `friends` in the database
 as described in `js/friends.js`.

--- a/api/remove_colleague.php
+++ b/api/remove_colleague.php
@@ -13,8 +13,19 @@ $data = json_decode(file_get_contents('php://input'), true);
 $other = isset($data['id']) ? (int)$data['id'] : 0;
 $uid = $_SESSION['user_id'];
 
-$stmt = $conn->prepare("DELETE FROM friends WHERE (user1 = ? AND user2 = ?) OR (user1 = ? AND user2 = ?)");
+
+// Remove the colleague relationship
+$stmt = $conn->prepare(
+    'DELETE FROM friends WHERE (user1 = ? AND user2 = ?) OR (user1 = ? AND user2 = ?)'
+);
 $stmt->bind_param('iiii', $uid, $other, $other, $uid);
 $stmt->execute();
+
+// Also remove any existing friend request records so a new request can be sent
+$req = $conn->prepare(
+    'DELETE FROM friend_requests WHERE (sender_id = ? AND receiver_id = ?) OR (sender_id = ? AND receiver_id = ?)'
+);
+$req->bind_param('iiii', $uid, $other, $other, $uid);
+$req->execute();
 
 echo json_encode(['status' => 'success']);


### PR DESCRIPTION
## Summary
- delete any friend_requests rows when removing a colleague
- document this behaviour in README

## Testing
- `php -l api/remove_colleague.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685720dbacbc83339247f048fc076b97