### PR TITLE
Remove wildcard CORS header

### DIFF
--- a/backend/database.php
+++ b/backend/database.php
@@ -1,9 +1,4 @@
 <?php
-
-header("Access-Control-Allow-Origin: *");
-header("Access-Control-Allow-Methods: GET, POST");
-header("Access-Control-Allow-Headers: Content-Type");
-
 // Load credentials
 $config = require __DIR__ . '/config.php';
 


### PR DESCRIPTION
## Summary
- drop `Access-Control-Allow-Origin` wildcard header from `database.php`

## Testing
- `php -l backend/database.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6858301cd5b4833388b1ff454f4377a1