### PR TITLE
Fix global DEBUG variable

### DIFF
--- a/js/colleague_suggestions.js
+++ b/js/colleague_suggestions.js
@@ -1,5 +1,6 @@
 // JS module for colleague suggestions based on user profile
-const DEBUG = false;
+window.DEBUG = window.DEBUG || false;
+var DEBUG = window.DEBUG;
 
 const initColleagueSuggestions = async () => {
     const container = document.getElementById('colleague-suggestions');

--- a/js/contact.js
+++ b/js/contact.js
@@ -1,5 +1,6 @@
 // Global debug flag
-const DEBUG = false;
+window.DEBUG = window.DEBUG || false;
+var DEBUG = window.DEBUG;
 
 document.addEventListener('DOMContentLoaded', async function () {
     try {

--- a/js/forgot_password.js
+++ b/js/forgot_password.js
@@ -1,5 +1,6 @@
 // Global debug flag
-const DEBUG = false;
+window.DEBUG = window.DEBUG || false;
+var DEBUG = window.DEBUG;
 
 document.addEventListener('DOMContentLoaded', function () {
     document.getElementById('forgot-password-form').addEventListener('submit', function (event) {

--- a/js/kalender.js
+++ b/js/kalender.js
@@ -26,7 +26,8 @@ const toggleYearButton = document.getElementById('toggle-year');
 let isYearView = false;
 
 // Debugging flag to enable verbose logging when needed
-const DEBUG = false;
+window.DEBUG = window.DEBUG || false;
+var DEBUG = window.DEBUG;
 if (DEBUG) console.log("🚀 kalender.js er lastet!");
 
 const msPerDay = 24 * 60 * 60 * 1000; // milliseconds in a day

--- a/js/login.js
+++ b/js/login.js
@@ -1,5 +1,6 @@
 // Global debug flag
-const DEBUG = false;
+window.DEBUG = window.DEBUG || false;
+var DEBUG = window.DEBUG;
 
 document.addEventListener('DOMContentLoaded', function () {
     const form = document.getElementById('form');

--- a/js/session.js
+++ b/js/session.js
@@ -1,5 +1,6 @@
 // Global debug flag
-const DEBUG = false;
+window.DEBUG = window.DEBUG || false;
+var DEBUG = window.DEBUG;
 
 document.addEventListener('DOMContentLoaded', async function () {
     // Verify the current session with the backend

--- a/js/user_profile.js
+++ b/js/user_profile.js
@@ -10,7 +10,8 @@ let avatarRemoveFlag = null;
 let cropperCanvas = null;
 
 // Debugging flag
-const DEBUG = false;
+window.DEBUG = window.DEBUG || false;
+var DEBUG = window.DEBUG;
 
 document.addEventListener('DOMContentLoaded', function () {
     const allColors = [


### PR DESCRIPTION
## Summary
- avoid redeclaration errors by using `window.DEBUG` across scripts

## Testing
- `node -c js/login.js`
- `for f in js/*.js; do node -c "$f"; done`

------
https://chatgpt.com/codex/tasks/task_e_68583212393c83339b3f2c0c31814e81