### PR TITLE
Fix JS 401 errors and missing element handler

### DIFF
--- a/js/forgot_password.js
+++ b/js/forgot_password.js
@@ -3,7 +3,9 @@ window.DEBUG = window.DEBUG || false;
 var DEBUG = window.DEBUG;
 
 document.addEventListener('DOMContentLoaded', function () {
-    document.getElementById('forgot-password-form').addEventListener('submit', function (event) {
+    const form = document.getElementById('forgot-password-form');
+    if (!form) return; // Script may be loaded on other pages
+    form.addEventListener('submit', function (event) {
         event.preventDefault();
 
         const email = document.getElementById('email').value;

--- a/js/kalender.js
+++ b/js/kalender.js
@@ -64,11 +64,19 @@ function loadColleagueColorPrefs() {
 }
 
 function loadCloseColleagues() {
+  if (!localStorage.getItem('userName')) {
+    const s = localStorage.getItem('closeColleagues');
+    closeColleagues = s ? JSON.parse(s) : {};
+    return;
+  }
   fetch('api/close_colleagues.php', { credentials: 'include' })
-    .then(r => r.json())
+    .then(r => {
+      if (!r.ok) throw new Error('unauthorized');
+      return r.json();
+    })
     .then(ids => {
       closeColleagues = {};
-      ids.forEach(id => closeColleagues[id] = true);
+      ids.forEach(id => (closeColleagues[id] = true));
       localStorage.setItem('closeColleagues', JSON.stringify(closeColleagues));
     })
     .catch(() => {
@@ -87,8 +95,19 @@ function saveColleagueColorPrefs() {
 }
 
 function loadShiftDeviations() {
+  if (!localStorage.getItem('userName')) {
+    const s = localStorage.getItem('shiftDeviations');
+    if (s) {
+      shiftDeviations = JSON.parse(s);
+      shiftDeviations.forEach(d => (d.startDate = new Date(d.startDate + 'T00:00')));
+    }
+    return;
+  }
   fetch('api/shift_deviations.php', { credentials: 'include' })
-    .then(r => r.json())
+    .then(r => {
+      if (!r.ok) throw new Error('unauthorized');
+      return r.json();
+    })
     .then(list => {
       shiftDeviations = list.map(d => ({
         id: d.id,
@@ -564,8 +583,16 @@ function saveSelectedColleagues() {
 
 
 function loadColleaguesList() {
+    if (!localStorage.getItem('userName')) {
+        colleagues = [];
+        renderColleagueList();
+        return;
+    }
     fetch('api/my_colleagues.php', { credentials: 'include' })
-        .then(r => r.json())
+        .then(r => {
+            if (!r.ok) throw new Error('unauthorized');
+            return r.json();
+        })
         .then(data => {
             if (!Array.isArray(data)) return;
             colleagues = data.filter(c => !c.info_hide);

--- a/js/session.js
+++ b/js/session.js
@@ -109,6 +109,12 @@ async function updatePendingBadge() {
     const bellBadge = document.getElementById('request-count');
     const requestBell = document.getElementById('request-bell');
     if (!badge && !bellBadge) return;
+    if (!localStorage.getItem('userName')) {
+        if (badge) badge.style.display = 'none';
+        if (bellBadge) bellBadge.style.display = 'none';
+        if (requestBell) requestBell.style.display = 'none';
+        return;
+    }
     try {
         const res = await fetch('api/pending_count.php', { credentials: 'include' });
         if (!res.ok) {


### PR DESCRIPTION
## Summary
- avoid JS error when forgot password form isn't present
- skip API requests when not logged in and fall back to localStorage
- hide pending badge if no user is logged in

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685867cddaa083338e31501030087807