### PR TITLE
Guard error logs with debug flag

### DIFF
--- a/forgot_password.html
+++ b/forgot_password.html
@@ -80,7 +80,7 @@
                     responseMessageDiv.style.fontWeight = 'bold';
                 })
                 .catch(error => {
-                    console.error('Feil ved tilbakestilling av passord:', error);
+                    if (DEBUG) console.error('Feil ved tilbakestilling av passord:', error);
                     responseMessageDiv.textContent = 'Det oppstod en feil. Vennligst prøv igjen senere.';
                     responseMessageDiv.style.display = 'block';
                     responseMessageDiv.style.color = '#28203f'; // Endret til svart

--- a/reset_password.html
+++ b/reset_password.html
@@ -100,7 +100,7 @@
                     }
                 })
                 .catch(error => {
-                    console.error('Feil ved tilbakestilling av passord:', error);
+                    if (DEBUG) console.error('Feil ved tilbakestilling av passord:', error);
                     responseMessageDiv.textContent = 'Det oppstod en feil. Vennligst prøv igjen senere.';
                     responseMessageDiv.style.display = 'block';
                     responseMessageDiv.style.color = '#28203f'; // Endret til svart


### PR DESCRIPTION
## Summary
- wrap error logs in forgot_password.html and reset_password.html with a debug guard

## Testing
- `grep -R "console.error" -n . | grep -v 'if (DEBUG' || true`

------
https://chatgpt.com/codex/tasks/task_e_68586dae0bfc8333912b80ad05e67dee