### PR TITLE
Add conditional debug mode to login

### DIFF
--- a/backend/login.php
+++ b/backend/login.php
@@ -1,7 +1,15 @@
 <?php
-ini_set('display_errors', 1);
-ini_set('display_startup_errors', 1);
-error_reporting(E_ALL);
+// Enable verbose error output only in development mode
+$devMode = getenv('DEV_MODE') === 'true';
+if ($devMode) {
+    ini_set('display_errors', 1);
+    ini_set('display_startup_errors', 1);
+    error_reporting(E_ALL);
+} else {
+    ini_set('display_errors', 0);
+    ini_set('display_startup_errors', 0);
+    error_reporting(0);
+}
 session_start();
 require_once 'database.php';
 


### PR DESCRIPTION
## Summary
- gate error reporting in `backend/login.php` behind an environment flag so debug output is disabled in production

## Testing
- `php -l backend/login.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68586dabb13c8333a3aeb130b944e1c5