### PR TITLE
Add CSRF protection to forms and API calls

### DIFF
--- a/api/cancel_request.php
+++ b/api/cancel_request.php
@@ -1,5 +1,7 @@
 <?php
 session_start();
+require_once __DIR__ . '/../backend/csrf.php';
+validate_csrf();
 header('Content-Type: application/json');
 require_once __DIR__ . '/../backend/database.php';
 

--- a/api/close_colleagues.php
+++ b/api/close_colleagues.php
@@ -1,5 +1,7 @@
 <?php
 session_start();
+require_once __DIR__ . '/../backend/csrf.php';
+validate_csrf();
 header('Content-Type: application/json');
 require_once __DIR__ . '/../backend/database.php';
 

--- a/api/remove_colleague.php
+++ b/api/remove_colleague.php
@@ -1,5 +1,7 @@
 <?php
 session_start();
+require_once __DIR__ . '/../backend/csrf.php';
+validate_csrf();
 header('Content-Type: application/json');
 require_once __DIR__ . '/../backend/database.php';
 

--- a/api/respond_request.php
+++ b/api/respond_request.php
@@ -1,5 +1,7 @@
 <?php
 session_start();
+require_once __DIR__ . '/../backend/csrf.php';
+validate_csrf();
 header('Content-Type: application/json');
 require_once __DIR__ . '/../backend/database.php';
 

--- a/api/send_request.php
+++ b/api/send_request.php
@@ -1,5 +1,7 @@
 <?php
 session_start();
+require_once __DIR__ . '/../backend/csrf.php';
+validate_csrf();
 header('Content-Type: application/json');
 require_once __DIR__ . '/../backend/database.php';
 

--- a/api/shift_deviations.php
+++ b/api/shift_deviations.php
@@ -1,5 +1,7 @@
 <?php
 session_start();
+require_once __DIR__ . '/../backend/csrf.php';
+validate_csrf();
 header('Content-Type: application/json');
 require_once __DIR__ . '/../backend/database.php';
 

--- a/backend/change_password.php
+++ b/backend/change_password.php
@@ -1,5 +1,7 @@
 <?php
 session_start();
+require_once 'csrf.php';
+validate_csrf();
 header('Content-Type: application/json');
 require_once 'database.php';
 

--- a/backend/csrf.php
+++ b/backend/csrf.php
@@ -1,0 +1,22 @@
+<?php
+session_start();
+function get_csrf_token() {
+    if (empty($_SESSION['csrf_token'])) {
+        $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+    }
+    return $_SESSION['csrf_token'];
+}
+
+function validate_csrf() {
+    $method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+    if ($method === 'POST' || $method === 'DELETE') {
+        $token = $_POST['csrf_token'] ?? ($_SERVER['HTTP_X_CSRF_TOKEN'] ?? '');
+        if (!isset($_SESSION['csrf_token']) || !hash_equals($_SESSION['csrf_token'], $token)) {
+            http_response_code(403);
+            header('Content-Type: application/json');
+            echo json_encode(['status' => 'error', 'message' => 'Invalid CSRF token']);
+            exit;
+        }
+    }
+}
+?>

--- a/backend/delete_profile.php
+++ b/backend/delete_profile.php
@@ -1,5 +1,7 @@
 <?php
 session_start();
+require_once 'csrf.php';
+validate_csrf();
 header('Content-Type: application/json');
 require_once 'database.php';
 

--- a/backend/forgot_password.php
+++ b/backend/forgot_password.php
@@ -2,6 +2,10 @@
 error_reporting(E_ALL);
 ini_set('display_errors', 1);
 
+session_start();
+require_once 'csrf.php';
+validate_csrf();
+
 use PHPMailer\PHPMailer\PHPMailer;
 use PHPMailer\PHPMailer\Exception;
 

--- a/backend/get_csrf_token.php
+++ b/backend/get_csrf_token.php
@@ -1,0 +1,6 @@
+<?php
+session_start();
+require_once 'csrf.php';
+header('Content-Type: application/json');
+echo json_encode(['token' => get_csrf_token()]);
+?>

--- a/backend/login.php
+++ b/backend/login.php
@@ -3,6 +3,8 @@ ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);
 error_reporting(E_ALL);
 session_start();
+require_once 'csrf.php';
+validate_csrf();
 require_once 'database.php';
 
 // Start session variables only after the user has been authenticated

--- a/backend/register.php
+++ b/backend/register.php
@@ -1,5 +1,7 @@
 <?php
 session_start();
+require_once 'csrf.php';
+validate_csrf();
 // Inkluder database.php for å koble til databasen
 require_once 'database.php';
 

--- a/backend/reset_password.php
+++ b/backend/reset_password.php
@@ -2,6 +2,10 @@
 error_reporting(E_ALL);
 ini_set('display_errors', 1);
 
+session_start();
+require_once 'csrf.php';
+validate_csrf();
+
 require_once 'database.php'; // Inkluder databasekonfigurasjon
 
 if ($_SERVER["REQUEST_METHOD"] == "POST") {

--- a/backend/send_mail.php
+++ b/backend/send_mail.php
@@ -3,6 +3,10 @@
 error_reporting(E_ALL);
 ini_set('display_errors', 1);
 
+session_start();
+require_once 'csrf.php';
+validate_csrf();
+
 use PHPMailer\PHPMailer\PHPMailer;
 use PHPMailer\PHPMailer\Exception;
 

--- a/backend/update_profile.php
+++ b/backend/update_profile.php
@@ -1,5 +1,7 @@
 <?php
 session_start();
+require_once 'csrf.php';
+validate_csrf();
 ob_clean();
 
 header('Content-Type: application/json');

--- a/change_password.html
+++ b/change_password.html
@@ -13,6 +13,7 @@
     <link rel="stylesheet" href="css/cookie-consent.css">
     <script defer src="js/message.js"></script>
     <script defer src="js/session.js"></script>
+    <script defer src="js/csrf.js"></script>
     <script defer src="js/change_password.js"></script>
     <script defer src="js/cookie-consent.js"></script>
 </head>
@@ -40,6 +41,7 @@
     <div class="login-box">
         <h1 class="page-title">Endre passord</h1>
         <form id="change-password-form" novalidate>
+            <input type="hidden" name="csrf_token" value="">
             <div class="form-group">
                 <input type="password" id="current-password" placeholder="Nåværende passord" required>
             </div>

--- a/contact.html
+++ b/contact.html
@@ -12,6 +12,7 @@
     <link rel="stylesheet" href="css/header.css">
     <link rel="stylesheet" href="css/cookie-consent.css">
     <script defer src="js/session.js"></script>
+    <script defer src="js/csrf.js"></script>
     <script defer src="js/contact.js"></script>
     <script defer src="js/cookie-consent.js"></script>
 
@@ -41,6 +42,7 @@
         <div class="contact-box">
             <h1 class="page-title">Kontakt oss</h1>
             <form id="contactForm" onsubmit="sendMail(event)">
+                <input type="hidden" name="csrf_token" value="">
    
                 <p>Har du spørsmål, tilbakemeldinger eller ønsker å komme i kontakt med oss? Fyll ut skjemaet nedenfor eller send mail til <a href="mailto:thomas@minturnus.no">thomas@minturnus.no</a>.</p>
                 
@@ -75,7 +77,8 @@
 
             fetch('backend/send_mail.php', {
                 method: 'POST',
-                body: formData
+                body: formData,
+                headers: { 'X-CSRF-Token': window.CSRF_TOKEN }
             })
             .then(response => {
                 if (!response.ok) {

--- a/forgot_password.html
+++ b/forgot_password.html
@@ -12,6 +12,7 @@
     <link rel="stylesheet" href="css/header.css">
     <link rel="stylesheet" href="css/cookie-consent.css">
     <script defer src="js/session.js"></script>
+    <script defer src="js/csrf.js"></script>
     <script defer src="js/cookie-consent.js"></script>
 </head>
 <body>
@@ -37,7 +38,8 @@
 
     <div class="login-box">
         <h1 class="page-title">Glemt Passord?</h1>
-        <form id="forgot-password-form" novalidate>   
+        <form id="forgot-password-form" novalidate>
+            <input type="hidden" name="csrf_token" value="">
             <div class="form-group">
                 <input type="email" id="email" name="email" placeholder="Skriv inn e-post" required>
             </div>

--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
     <script defer src="js/user_card.js"></script>
     <script defer src="js/kalender.js"></script>
     <script defer src="js/session.js"></script>
+    <script defer src="js/csrf.js"></script>
     <script defer src="js/cookie-consent.js"></script>
 </head>
 <body>
@@ -87,6 +88,7 @@
     <div id="deviation-section">
         <button id="toggle-deviation" class="btn" style="display:none;">Legg til avvik fra turnus</button>
         <form id="deviation-form" class="shift-form" style="display:none;">
+            <input type="hidden" name="csrf_token" value="">
             <h3>Avvik fra egen turnus</h3>
             <label for="deviation-start">Startdato</label>
             <input type="date" id="deviation-start">

--- a/js/change_password.js
+++ b/js/change_password.js
@@ -13,7 +13,10 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         fetch('backend/change_password.php', {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
+            headers: { 
+                'Content-Type': 'application/json',
+                'X-CSRF-Token': window.CSRF_TOKEN
+            },
             body: JSON.stringify({ current, new: newPass }),
             credentials: 'include'
         })

--- a/js/csrf.js
+++ b/js/csrf.js
@@ -1,0 +1,15 @@
+window.CSRF_TOKEN = null;
+async function loadCsrfToken() {
+    try {
+        const res = await fetch('backend/get_csrf_token.php', { credentials: 'include' });
+        const data = await res.json();
+        window.CSRF_TOKEN = data.token;
+        document.querySelectorAll('input[name="csrf_token"]').forEach(el => {
+            el.value = window.CSRF_TOKEN;
+        });
+    } catch (e) {
+        console.error('Failed to get CSRF token', e);
+    }
+}
+
+document.addEventListener('DOMContentLoaded', loadCsrfToken);

--- a/js/forgot_password.js
+++ b/js/forgot_password.js
@@ -13,7 +13,8 @@ document.addEventListener('DOMContentLoaded', function () {
         fetch('backend/forgot_password.php', {
             method: 'POST',
             headers: {
-                'Content-Type': 'application/json'
+                'Content-Type': 'application/json',
+                'X-CSRF-Token': window.CSRF_TOKEN
             },
             body: JSON.stringify({ email })
         })

--- a/js/friends.js
+++ b/js/friends.js
@@ -87,7 +87,7 @@ function sendRequest(id, btn) {
     return fetch('api/send_request.php', {
         credentials: 'include',
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': window.CSRF_TOKEN },
         body: JSON.stringify({ id })
     })
         .then(r => r.json())
@@ -127,7 +127,7 @@ function respondRequest(id, accept) {
     fetch('api/respond_request.php', {
         credentials: 'include',
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': window.CSRF_TOKEN },
         body: JSON.stringify({ id, accept })
     })
         .then(() => {
@@ -154,7 +154,7 @@ function removeColleague(id) {
     fetch('api/remove_colleague.php', {
         credentials: 'include',
         method: 'DELETE',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': window.CSRF_TOKEN },
         body: JSON.stringify({ id })
     })
     .then(() => loadColleagues());
@@ -182,7 +182,7 @@ function cancelRequest(id) {
     fetch('api/cancel_request.php', {
         credentials: 'include',
         method: 'DELETE',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': window.CSRF_TOKEN },
         body: JSON.stringify({ id })
     }).then(() => loadSentRequests());
 }

--- a/js/kalender.js
+++ b/js/kalender.js
@@ -460,7 +460,7 @@ function addDeviation() {
     fetch('api/shift_deviations.php', {
         credentials: 'include',
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': window.CSRF_TOKEN },
         body: JSON.stringify(payload)
     })
     .then(r => r.json())
@@ -486,7 +486,7 @@ function deleteDeviation(index) {
     fetch('api/shift_deviations.php', {
         credentials: 'include',
         method: 'DELETE',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': window.CSRF_TOKEN },
         body: JSON.stringify({ id: dev.id })
     })
     .then(() => {

--- a/js/login.js
+++ b/js/login.js
@@ -28,6 +28,7 @@ document.addEventListener('DOMContentLoaded', function () {
                     method: 'POST',
                     headers: {
                         'Accept': 'application/json',
+                        'X-CSRF-Token': window.CSRF_TOKEN
                     },
                     body: formData,
                     credentials: 'include'

--- a/js/user_profile.js
+++ b/js/user_profile.js
@@ -347,7 +347,8 @@ function updateUserProfile() {
     fetch('backend/update_profile.php', {
         method: 'POST',
         body: formData,
-        credentials: 'include'
+        credentials: 'include',
+        headers: { 'X-CSRF-Token': window.CSRF_TOKEN }
     })
     .then(response => {
         if (DEBUG) console.log('HTTP response status:', response.status);
@@ -440,7 +441,8 @@ function deleteProfile() {
 
     fetch('backend/delete_profile.php', {
         method: 'POST',
-        credentials: 'include'
+        credentials: 'include',
+        headers: { 'X-CSRF-Token': window.CSRF_TOKEN }
     })
     .then(r => r.json())
     .then(data => {

--- a/login.html
+++ b/login.html
@@ -13,6 +13,7 @@
     <link rel="stylesheet" href="css/cookie-consent.css">
     <script defer src="js/message.js"></script>
     <script defer src="js/session.js"></script>
+    <script defer src="js/csrf.js"></script>
     <script defer src="js/login.js"></script>
     <script defer src="js/forgot_password.js"></script>
     <script defer src="js/cookie-consent.js"></script>
@@ -39,6 +40,7 @@
         </nav>
     <div class="login-box">
         <form id="form" data-action="login" method="post" novalidate>
+            <input type="hidden" name="csrf_token" value="">
             <h1 class="page-title">Logg inn</h1>
             <div id="error-messages" class="error-messages"></div><br>
             <div class="form-group">

--- a/register.html
+++ b/register.html
@@ -12,6 +12,7 @@
     <link rel="stylesheet" href="css/header.css">
     <link rel="stylesheet" href="css/cookie-consent.css">
     <script defer src="js/session.js"></script>
+    <script defer src="js/csrf.js"></script>
     <script defer src="js/login.js"></script>
     <script defer src="js/cookie-consent.js"></script>
 </head>
@@ -38,6 +39,7 @@
     
     <div class="login-box">
         <form id="form" data-action="register" novalidate>
+            <input type="hidden" name="csrf_token" value="">
             <h1 class="page-title">Registrer deg</h1>
             <div class="form-group"> 
                 <div id="error-messages" class="error-messages"></div> <!-- Feilmeldingscontainer -->

--- a/reset_password.html
+++ b/reset_password.html
@@ -12,6 +12,7 @@
     <link rel="stylesheet" href="css/header.css">
     <link rel="stylesheet" href="css/cookie-consent.css">
     <script defer src="js/session.js"></script>
+    <script defer src="js/csrf.js"></script>
     <script defer src="js/cookie-consent.js"></script>
 </head>
 <body>
@@ -38,6 +39,7 @@
     <div class="login-box">
         <h1 class="page-title">Tilbakestill Passord</h1>
         <form id="reset-password-form" novalidate>
+            <input type="hidden" name="csrf_token" value="">
             <div class="form-group">
                 <input type="password" id="new-password" name="new-password" placeholder="Nytt passord" required>
             </div>
@@ -82,7 +84,8 @@
                 fetch('backend/reset_password.php', {
                     method: 'POST',
                     headers: {
-                        'Content-Type': 'application/json'
+                        'Content-Type': 'application/json',
+                        'X-CSRF-Token': window.CSRF_TOKEN
                     },
                     body: JSON.stringify({ token: token, new_password: newPassword })
                 })

--- a/user_profile.html
+++ b/user_profile.html
@@ -14,6 +14,7 @@
     <link rel="stylesheet" href="css/cookie-consent.css">
     <script defer src="js/message.js"></script>
     <script defer src="js/session.js"></script>
+    <script defer src="js/csrf.js"></script>
     <script defer src="js/user_card.js"></script>
     <script defer src="js/user_profile.js"></script>
     <script defer src="js/cookie-consent.js"></script>
@@ -41,6 +42,7 @@
 
     <div class="contact-box user-profile-box">
         <form id="user-profile-form" class="user-profile" novalidate>
+            <input type="hidden" name="csrf_token" value="">
             <h1 class="page-title">Brukerprofil</h1>
 
             <div class="avatar-section">


### PR DESCRIPTION
## Summary
- add CSRF utility functions and endpoint
- include CSRF tokens in all forms
- fetch CSRF token with new `csrf.js`
- validate tokens in backend and API scripts
- send token headers in fetch requests

## Testing
- `php -l backend/csrf.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68586daec30883339fb09f7614574600