### PR TITLE
Fix share link to invitation page

### DIFF
--- a/js/friends.js
+++ b/js/friends.js
@@ -55,7 +55,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const qrBox = document.getElementById('qr-code');
     const copyFeedback = document.getElementById('copy-feedback');
 
-    let shareURL = 'https://minturnus.no/venn';
+    let shareURL = 'https://minturnus.no/venn.html';
     const refName = localStorage.getItem('userName');
     if (refName) {
         shareURL += '?ref=' + encodeURIComponent(refName);


### PR DESCRIPTION
## Summary
- point share URL to `venn.html` so QR links don't break

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6858769437e4833382dd0d80d1face28