### PR TITLE
Fix calendar init on non-calendar pages

### DIFF
--- a/js/bundle.js
+++ b/js/bundle.js
@@ -511,6 +511,11 @@ const dayNames = [
 ];
 
 document.addEventListener('DOMContentLoaded', function () {
+    // Only initialize the calendar when the required elements are present
+    if (!calendarGrid) {
+        return;
+    }
+
     renderWeekdayRow();
     initializeEventListeners();
     loadShiftsFromLocalStorage();

--- a/js/bundle.min.js
+++ b/js/bundle.min.js
@@ -511,6 +511,7 @@ const dayNames = [
 ];
 
 document.addEventListener('DOMContentLoaded', function () {
+    if (!calendarGrid) { return; }
     renderWeekdayRow();
     initializeEventListeners();
     loadShiftsFromLocalStorage();


### PR DESCRIPTION
## Summary
- avoid calendar initialization when calendar elements are missing

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68591d9f73088333ae4688b85a7c77a7