### PR TITLE
Fix updateView crash when calendar not present

### DIFF
--- a/js/bundle.js
+++ b/js/bundle.js
@@ -1297,19 +1297,22 @@ function renderYearCalendar(year) {
 }
 
 function updateView() {
+    if (!container) return;
+    const weekdayRow = document.querySelector('.weekday-row');
+
     if (isYearView) {
         container.classList.add('year-view');
-        calendarGrid.style.display = 'none';
-        document.querySelector('.weekday-row').style.display = 'none';
-        yearContainer.style.display = 'grid';
-        renderYearCalendar(currentYear);
+        if (calendarGrid) calendarGrid.style.display = 'none';
+        if (weekdayRow) weekdayRow.style.display = 'none';
+        if (yearContainer) yearContainer.style.display = 'grid';
+        if (yearContainer) renderYearCalendar(currentYear);
         if (toggleYearButton) toggleYearButton.textContent = 'Vis måned';
     } else {
         container.classList.remove('year-view');
-        yearContainer.style.display = 'none';
-        document.querySelector('.weekday-row').style.display = 'grid';
-        calendarGrid.style.display = 'grid';
-        renderCalendar(currentMonth, currentYear);
+        if (yearContainer) yearContainer.style.display = 'none';
+        if (weekdayRow) weekdayRow.style.display = 'grid';
+        if (calendarGrid) calendarGrid.style.display = 'grid';
+        if (calendarGrid) renderCalendar(currentMonth, currentYear);
         if (toggleYearButton) toggleYearButton.textContent = 'Vis år';
     }
 }
@@ -1357,7 +1360,9 @@ const dayPopup = document.getElementById('day-popup');
 let outsideHandler = null;
 
 // Initialiser kalenderen
-updateView();
+if (container) {
+    updateView();
+}
 
 function getShiftsForDate(date) {
     const result = [];

--- a/js/bundle.min.js
+++ b/js/bundle.min.js
@@ -1293,19 +1293,22 @@ function renderYearCalendar(year) {
 }
 
 function updateView() {
+    if (!container) return;
+    const weekdayRow = document.querySelector('.weekday-row');
+
     if (isYearView) {
         container.classList.add('year-view');
-        calendarGrid.style.display = 'none';
-        document.querySelector('.weekday-row').style.display = 'none';
-        yearContainer.style.display = 'grid';
-        renderYearCalendar(currentYear);
+        if (calendarGrid) calendarGrid.style.display = 'none';
+        if (weekdayRow) weekdayRow.style.display = 'none';
+        if (yearContainer) yearContainer.style.display = 'grid';
+        if (yearContainer) renderYearCalendar(currentYear);
         if (toggleYearButton) toggleYearButton.textContent = 'Vis måned';
     } else {
         container.classList.remove('year-view');
-        yearContainer.style.display = 'none';
-        document.querySelector('.weekday-row').style.display = 'grid';
-        calendarGrid.style.display = 'grid';
-        renderCalendar(currentMonth, currentYear);
+        if (yearContainer) yearContainer.style.display = 'none';
+        if (weekdayRow) weekdayRow.style.display = 'grid';
+        if (calendarGrid) calendarGrid.style.display = 'grid';
+        if (calendarGrid) renderCalendar(currentMonth, currentYear);
         if (toggleYearButton) toggleYearButton.textContent = 'Vis år';
     }
 }
@@ -1353,7 +1356,9 @@ const dayPopup = document.getElementById('day-popup');
 let outsideHandler = null;
 
 // Initialiser kalenderen
-updateView();
+if (container) {
+    updateView();
+}
 
 function getShiftsForDate(date) {
     const result = [];

--- a/js/kalender.js
+++ b/js/kalender.js
@@ -1011,19 +1011,22 @@ function renderYearCalendar(year) {
 }
 
 function updateView() {
+    if (!container) return;
+    const weekdayRow = document.querySelector('.weekday-row');
+
     if (isYearView) {
         container.classList.add('year-view');
-        calendarGrid.style.display = 'none';
-        document.querySelector('.weekday-row').style.display = 'none';
-        yearContainer.style.display = 'grid';
-        renderYearCalendar(currentYear);
+        if (calendarGrid) calendarGrid.style.display = 'none';
+        if (weekdayRow) weekdayRow.style.display = 'none';
+        if (yearContainer) yearContainer.style.display = 'grid';
+        if (yearContainer) renderYearCalendar(currentYear);
         if (toggleYearButton) toggleYearButton.textContent = 'Vis måned';
     } else {
         container.classList.remove('year-view');
-        yearContainer.style.display = 'none';
-        document.querySelector('.weekday-row').style.display = 'grid';
-        calendarGrid.style.display = 'grid';
-        renderCalendar(currentMonth, currentYear);
+        if (yearContainer) yearContainer.style.display = 'none';
+        if (weekdayRow) weekdayRow.style.display = 'grid';
+        if (calendarGrid) calendarGrid.style.display = 'grid';
+        if (calendarGrid) renderCalendar(currentMonth, currentYear);
         if (toggleYearButton) toggleYearButton.textContent = 'Vis år';
     }
 }
@@ -1071,7 +1074,9 @@ const dayPopup = document.getElementById('day-popup');
 let outsideHandler = null;
 
 // Initialiser kalenderen
-updateView();
+if (container) {
+    updateView();
+}
 
 function getShiftsForDate(date) {
     const result = [];


### PR DESCRIPTION
## Summary
- add guard clauses for missing calendar container in `updateView`
- only call `updateView` when container exists

## Testing
- `php` command failed: `php: No such file or directory`


------
https://chatgpt.com/codex/tasks/task_e_68591ffa02e08333a38c5529207851b3